### PR TITLE
Replace Revit references by NuGet package.

### DIFF
--- a/CS/RevitLookup.csproj
+++ b/CS/RevitLookup.csproj
@@ -120,12 +120,24 @@
     <Reference Include="PresentationCore">
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="RevitAPI">
-      <HintPath>..\..\..\..\Program Files\Autodesk\Revit 2017\RevitAPI.dll</HintPath>
+    <Reference Include="RevitAPI, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>packages\Revit-2017x64.Base.2.0.0\lib\net452\RevitAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RevitAPIUI">
-      <HintPath>..\..\..\..\Program Files\Autodesk\Revit 2017\RevitAPIUI.dll</HintPath>
+    <Reference Include="RevitAPIIFC, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>packages\Revit-2017x64.Base.2.0.0\lib\net452\RevitAPIIFC.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIMacros, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>packages\Revit-2017x64.Base.2.0.0\lib\net452\RevitAPIMacros.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIUI, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>packages\Revit-2017x64.Base.2.0.0\lib\net452\RevitAPIUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPIUIMacros, Version=17.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>packages\Revit-2017x64.Base.2.0.0\lib\net452\RevitAPIUIMacros.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System">
@@ -529,6 +541,9 @@
       <ProductName>Windows Installer 3.1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/CS/packages.config
+++ b/CS/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Revit-2017x64.Base" version="2.0.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
I replaced Revit references by NuGet package: https://www.nuget.org/packages/Revit-2017x64.Base/
I did it because some users (_which aren't programmers_) had the problems with code compiling of this project. They got the problem with Revit references and asked me about it. They want to have the newest version of RevitLookup, but you don't provide the compiled result on the releases page.

Therefore I wrote the video for them: https://www.youtube.com/watch?v=ajgSGp6gp5E

I suggest to accept this change and to use a NuGet-package.

Your `.gitignore` file contains the `packages` ignoring rule. Therefore if you will decide to apply my change then the assemblies of the NuGet-package will not be added into the repository. Therefore, it is necessary either to comment this rule, or require to NuGet manager to recovery of these files:

![The Screen](http://s8.hostingkartinok.com/uploads/images/2016/12/dbbdc7dae281eff67caa6d5b4537710c.png)


Thank you.