### PR TITLE
Provided close-with-ESC to all forms by assigning the cancel button

### DIFF
--- a/CS/EventTrack/Forms/EventsForm.designer.cs
+++ b/CS/EventTrack/Forms/EventsForm.designer.cs
@@ -126,6 +126,7 @@ namespace RevitLookup.EventTrack.Forms
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_bnCancel;
             this.ClientSize = new System.Drawing.Size(389, 241);
             this.Controls.Add(this.m_bnCancel);
             this.Controls.Add(this.m_tabCtrl);

--- a/CS/Snoop/Forms/Objects.cs
+++ b/CS/Snoop/Forms/Objects.cs
@@ -323,6 +323,7 @@ namespace RevitLookup.Snoop.Forms
       // Objects
       // 
       this.AutoScaleBaseSize = new System.Drawing.Size( 5, 13 );
+      this.CancelButton = this.m_bnOK;
       this.ClientSize = new System.Drawing.Size( 800, 492 );
       this.Controls.Add( this.toolStrip1 );
       this.Controls.Add( this.m_lvData );

--- a/CS/Snoop/Forms/ParamEnum.Designer.cs
+++ b/CS/Snoop/Forms/ParamEnum.Designer.cs
@@ -157,6 +157,7 @@ namespace RevitLookup.Snoop.Forms {
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_bnOk;
             this.ClientSize = new System.Drawing.Size(613, 483);
             this.Controls.Add(this.toolStrip1);
             this.Controls.Add(this.m_bnOk);

--- a/CS/Test/ExIm/BrowseCategory.Designer.cs
+++ b/CS/Test/ExIm/BrowseCategory.Designer.cs
@@ -53,6 +53,7 @@ namespace RevitLookup.ExIm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_OkBtn;
             this.ClientSize = new System.Drawing.Size(292, 266);
             this.Controls.Add(this.m_OkBtn);
             this.Controls.Add(this.m_treeView);

--- a/CS/Test/Forms/Elements.Designer.cs
+++ b/CS/Test/Forms/Elements.Designer.cs
@@ -57,6 +57,7 @@ namespace RevitLookup.Test.Forms
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_btnOk;
             this.ClientSize = new System.Drawing.Size(289, 376);
             this.Controls.Add(this.m_btnOk);
             this.Controls.Add(this.m_treeView);

--- a/CS/Test/Forms/Levels.Designer.cs
+++ b/CS/Test/Forms/Levels.Designer.cs
@@ -78,6 +78,7 @@ namespace RevitLookup.Test.Forms
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_btnOk;
             this.ClientSize = new System.Drawing.Size(302, 310);
             this.Controls.Add(this.m_levlv);
             this.Controls.Add(this.m_btnOk);

--- a/CS/Test/SDKSamples/AnalyticalSupportData/InfoForm.designer.cs
+++ b/CS/Test/SDKSamples/AnalyticalSupportData/InfoForm.designer.cs
@@ -125,6 +125,7 @@ namespace RevitLookup.Test.SDKSamples.AnalyticalSupportData
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_bnOK;
             this.ClientSize = new System.Drawing.Size(677, 393);
             this.Controls.Add(this.m_dataGrid);
             this.Controls.Add(this.m_bnOK);

--- a/CS/Test/SDKSamples/CreateSheet/AllViewsForm.designer.cs
+++ b/CS/Test/SDKSamples/CreateSheet/AllViewsForm.designer.cs
@@ -132,6 +132,7 @@ namespace RevitLookup.Test.SDKSamples.CreateSheet {
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_bnCancel;
             this.ClientSize = new System.Drawing.Size(461, 301);
             this.Controls.Add(this.m_grpboxSheet);
             this.Controls.Add(this.m_grpboxViews);

--- a/CS/Test/SDKSamples/TypeSelector/TypeSelectorForm.Designer.cs
+++ b/CS/Test/SDKSamples/TypeSelector/TypeSelectorForm.Designer.cs
@@ -83,6 +83,7 @@ namespace RevitLookup.Test.SDKSamples.TypeSelector {
             this.AcceptButton = this.m_bnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.m_bnOK;
             this.ClientSize = new System.Drawing.Size(642, 425);
             this.Controls.Add(this.m_txtSymbols);
             this.Controls.Add(this.m_txtElements);


### PR DESCRIPTION
I assigned the CancelButton field (in each form that didn't have a CancelButton field assigned yet) to the proper button available.

This provides the function of closing each form with the keyboard ESC key (which can be faster than pointing and clicking your mouse).