### PR TITLE
Add UnitType property to CollectorExtParams.cs

### DIFF
--- a/CS/Snoop/CollectorExts/CollectorExtParams.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtParams.cs
@@ -174,6 +174,7 @@ namespace RevitLookup.Snoop.CollectorExts
             data.Add(new Snoop.Data.String("Name", paramDef.Name));
             data.Add(new Snoop.Data.String("Parameter type", paramDef.ParameterType.ToString()));
             data.Add(new Snoop.Data.String("Parameter group", paramDef.ParameterGroup.ToString()));
+	    data.Add(new Snoop.Data.String("Unit type", paramDef.UnitType.ToString()));
 
 			ExternalDefinition extDef = paramDef as ExternalDefinition;
 			if (extDef != null) {


### PR DESCRIPTION
Added UnitType property from Definition Class.

The UnitType property seemed to be missing from the [Definition class](http://www.revitapidocs.com/2017/e9e4ea63-d291-2a06-6be4-b6cce810ba92.htm).

![image](https://cloud.githubusercontent.com/assets/5968613/22527278/d229948e-e8ce-11e6-9baa-a68fccf6a4f6.png)
