### PR TITLE
Old bug fixes and improvements of the new approach

### DIFF
--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -258,6 +258,7 @@ namespace RevitLookup.Snoop.CollectorExts
             return type
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
                 .Where(x => x.GetMethod != null)
+                .OrderBy(x=>x.Name)
                 .ToArray();
         }
 
@@ -268,6 +269,7 @@ namespace RevitLookup.Snoop.CollectorExts
                 .Where(x => !x.GetParameters().Any()
                        && x.ReturnType != typeof(void)
                        && !x.IsSpecialName)
+                .OrderBy(x => x.Name)
             .ToArray();
 
             return mInfo;

--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -238,6 +238,10 @@ namespace RevitLookup.Snoop.CollectorExts
                 {
                     data.Add(new Snoop.Data.Xyz(info.Name, returnValue as XYZ));
                 }
+                else if (expectedType.IsEnum)
+                {
+                    data.Add(new Snoop.Data.String(info.Name, returnValue.ToString()));
+                }
                 else
                 {
                     data.Add(new Snoop.Data.Object(info.Name, returnValue as object));

--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -251,13 +251,19 @@ namespace RevitLookup.Snoop.CollectorExts
 
         private PropertyInfo[] GetElementProperties(Type type)
         {
-            return type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.GetMethod != null).ToArray();
+            return type
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Where(x => x.GetMethod != null)
+                .ToArray();
         }
 
         private MethodInfo[] GetElementMethods(Type type)
         {
-            MethodInfo[] mInfo = type.GetMethods().Where(x => x.GetParameters().Count() == 0
-            && x.ReturnType != typeof(void))
+            MethodInfo[] mInfo = type
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Where(x => !x.GetParameters().Any()
+                       && x.ReturnType != typeof(void)
+                       && !x.IsSpecialName)
             .ToArray();
 
             return mInfo;

--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -83,7 +83,7 @@ namespace RevitLookup.Snoop.CollectorExts
                 List<string> currentTypeProperties = new List<string>();
                 List<string> currentTypeMethods = new List<string>();
 
-                if (properties.Length > 0) data.Add(new Snoop.Data.MemberSeparator("PROPERTIES"));
+                if (properties.Length > 0) data.Add(new Snoop.Data.MemberSeparatorWithOffset("Properties"));
 
                 foreach (PropertyInfo pi in properties)
                 {
@@ -95,7 +95,7 @@ namespace RevitLookup.Snoop.CollectorExts
 
                 seenProperties.AddRange(currentTypeProperties);
 
-                if (methods.Length > 0) data.Add(new Snoop.Data.MemberSeparator("METHODS"));
+                if (methods.Length > 0) data.Add(new Snoop.Data.MemberSeparatorWithOffset("Methods"));
 
                 foreach (MethodInfo mi in methods)
                 {

--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -193,7 +193,7 @@ namespace RevitLookup.Snoop.CollectorExts
                     double? val = returnValue as double?;
                     data.Add(new Snoop.Data.Double(info.Name, val.Value));
                 }
-                else if (expectedType == typeof(GeometryObject) || expectedType == typeof(GeometryElement))
+                else if ((expectedType == typeof(GeometryObject) || expectedType == typeof(GeometryElement)) && elem is Element)
                 {
                     data.Add(new Snoop.Data.ElementGeometry(info.Name, elem as Element, m_app.Application));
                 }

--- a/CS/Snoop/Data/MemberSeparator.cs
+++ b/CS/Snoop/Data/MemberSeparator.cs
@@ -41,4 +41,17 @@ namespace RevitLookup.Snoop.Data
 
         }
     }
+
+    public class MemberSeparatorWithOffset : MemberSeparator
+    {
+        public MemberSeparatorWithOffset(string val)
+            : base(val)
+        {
+        }
+
+        override public string StrValue()
+        {
+            return string.Format("  --- {0} ---", name);
+        }
+    }
 }

--- a/CS/Snoop/Forms/Geometry.cs
+++ b/CS/Snoop/Forms/Geometry.cs
@@ -33,230 +33,210 @@ using Autodesk.Revit.DB;
 
 namespace RevitLookup.Snoop.Forms
 {
-   /// <summary>
-   /// Summary description for BindingMap form.
-   /// </summary>
+    /// <summary>
+    /// Summary description for BindingMap form.
+    /// </summary>
 
-   public class Geometry : RevitLookup.Snoop.Forms.ObjTreeBase
-   {
-      protected Element m_elem = null;
-      protected Autodesk.Revit.ApplicationServices.Application m_app = null;
+    public class Geometry : RevitLookup.Snoop.Forms.ObjTreeBase
+    {
+        protected Element m_elem = null;
+        protected Autodesk.Revit.ApplicationServices.Application m_app = null;
 
-      public
-      Geometry(Autodesk.Revit.DB.Element elem, Autodesk.Revit.ApplicationServices.Application app)
-      {
-         this.Text = "Element Geometry";
+        public
+        Geometry(Autodesk.Revit.DB.Element elem, Autodesk.Revit.ApplicationServices.Application app)
+        {
+            this.Text = "Element Geometry";
 
-         m_elem = elem;
-         m_app = app;
+            m_elem = elem;
+            m_app = app;
 
-         m_tvObjs.BeginUpdate();
-         AddObjectsToTree(elem, m_tvObjs.Nodes);
-         m_tvObjs.EndUpdate();
-      }
+            m_tvObjs.BeginUpdate();
+            AddObjectsToTree(elem, m_tvObjs.Nodes);
+            m_tvObjs.EndUpdate();
+        }
 
-      protected void
-      AddObjectsToTree(Element elem, TreeNodeCollection curNodes)
-      {
-         Autodesk.Revit.DB.Options geomOp = m_app.Create.NewGeometryOptions();
-         geomOp.ComputeReferences = true;
-         TreeNode tmpNode;
+        protected void
+        AddObjectsToTree(Element elem, TreeNodeCollection curNodes)
+        {
+            Autodesk.Revit.DB.Options geomOp;
 
-         // add geometry with the View set to null.
-         TreeNode rootNode1 = new TreeNode("View = null");
-         curNodes.Add(rootNode1);
+            TreeNode tmpNode;
 
-         tmpNode = new TreeNode("Detail Level = Undefined");
-         geomOp.DetailLevel = ViewDetailLevel.Undefined;
-         tmpNode.Tag = elem.get_Geometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
+            // add geometry with the View set to null.
+            TreeNode rootNode1 = new TreeNode("View = null");
+            curNodes.Add(rootNode1);
+            foreach (ViewDetailLevel viewDetailLevel in Enum.GetValues(typeof(ViewDetailLevel)))
+            {
+                tmpNode = new TreeNode("Detail Level = " + viewDetailLevel.ToString());
+                // IMPORTANT!!! Need to create options each time when you are 
+                // getting geometry. In other case, all the geometry you got at the 
+                // previous step will be owerriten according with the latest DetailLevel
+                geomOp = m_app.Create.NewGeometryOptions();
+                geomOp.ComputeReferences = true;
+                geomOp.DetailLevel = viewDetailLevel;
+                tmpNode.Tag = elem.get_Geometry(geomOp);
+                rootNode1.Nodes.Add(tmpNode);
+            }
 
-         tmpNode = new TreeNode("Detail Level = Coarse");
-         geomOp.DetailLevel = ViewDetailLevel.Coarse;
-         tmpNode.Tag = elem.get_Geometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
 
-         tmpNode = new TreeNode("Detail Level = Medium");
-         geomOp.DetailLevel = ViewDetailLevel.Medium;
-         tmpNode.Tag = elem.get_Geometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
 
-         tmpNode = new TreeNode("Detail Level = Fine");
-         geomOp.DetailLevel = ViewDetailLevel.Fine;
-         tmpNode.Tag = elem.get_Geometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
-
-         // SOFiSTiK FS
-         // add model geometry including geometry objects not set as Visible.
-         {
-            Autodesk.Revit.DB.Options opts = m_app.Create.NewGeometryOptions();
-            opts.ComputeReferences = true;
-            opts.IncludeNonVisibleObjects = true;
-
+            // add model geometry including geometry objects not set as Visible.
             TreeNode rootNode = new TreeNode("View = null - Including geometry objects not set as Visible");
             curNodes.Add(rootNode);
+            foreach (ViewDetailLevel viewDetailLevel in Enum.GetValues(typeof(ViewDetailLevel)))
+            {
+                tmpNode = new TreeNode("Detail Level = " + viewDetailLevel.ToString());
+                // IMPORTANT!!! Need to create options each time when you are 
+                // getting geometry. In other case, all the geometry you got at the 
+                // previous step will be owerriten according with the latest DetailLevel
+                geomOp = m_app.Create.NewGeometryOptions();
+                geomOp.ComputeReferences = true;
+                geomOp.IncludeNonVisibleObjects = true;
+                geomOp.DetailLevel = viewDetailLevel;
+                tmpNode.Tag = elem.get_Geometry(geomOp);
+                rootNode.Nodes.Add(tmpNode);
+            }
+
+            // now add geometry with the View set to the current view
+            if (elem.Document.ActiveView != null)
+            {
+                Options geomOp2 = m_app.Create.NewGeometryOptions();
+                geomOp2.ComputeReferences = true;
+                geomOp2.View = elem.Document.ActiveView;
+
+                TreeNode rootNode2 = new TreeNode("View = Document.ActiveView");
+                rootNode2.Tag = elem.get_Geometry(geomOp2);
+                curNodes.Add(rootNode2);
+
+                // SOFiSTiK FS
+                // add model geometry including geometry objects not set as Visible.
+                {
+                    Autodesk.Revit.DB.Options opts = m_app.Create.NewGeometryOptions();
+                    opts.ComputeReferences = true;
+                    opts.IncludeNonVisibleObjects = true;
+                    opts.View = elem.Document.ActiveView;
+
+                    rootNode = new TreeNode("View = Document.ActiveView - Including geometry objects not set as Visible");
+                    curNodes.Add(rootNode);
+
+                    rootNode.Tag = elem.get_Geometry(opts);
+                }
+            }
+        }
+    }
+
+
+
+
+    //SOFiSTiK FS
+
+    public class OriginalGeometry : RevitLookup.Snoop.Forms.ObjTreeBase
+    {
+        protected Element m_elem = null;
+        protected Autodesk.Revit.ApplicationServices.Application m_app = null;
+
+        public
+        OriginalGeometry(Autodesk.Revit.DB.FamilyInstance elem, Autodesk.Revit.ApplicationServices.Application app)
+        {
+            this.Text = "Element Original Geometry";
+
+            m_elem = elem;
+            m_app = app;
+
+            m_tvObjs.BeginUpdate();
+            AddObjectsToTree(elem, m_tvObjs.Nodes);
+            m_tvObjs.EndUpdate();
+        }
+
+        protected void
+        AddObjectsToTree(FamilyInstance elem, TreeNodeCollection curNodes)
+        {
+            Autodesk.Revit.DB.Options geomOp = m_app.Create.NewGeometryOptions();
+            geomOp.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!
+            TreeNode tmpNode;
+
+            // add geometry with the View set to null.
+            TreeNode rootNode1 = new TreeNode("View = null");
+            curNodes.Add(rootNode1);
 
             tmpNode = new TreeNode("Detail Level = Undefined");
-            opts.DetailLevel = ViewDetailLevel.Undefined;
-            tmpNode.Tag = elem.get_Geometry(opts);
-            rootNode.Nodes.Add(tmpNode);
+            geomOp.DetailLevel = ViewDetailLevel.Undefined;
+            tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
+            rootNode1.Nodes.Add(tmpNode);
 
             tmpNode = new TreeNode("Detail Level = Coarse");
-            opts.DetailLevel = ViewDetailLevel.Coarse;
-            tmpNode.Tag = elem.get_Geometry(opts);
-            rootNode.Nodes.Add(tmpNode);
+            geomOp.DetailLevel = ViewDetailLevel.Coarse;
+            tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
+            rootNode1.Nodes.Add(tmpNode);
 
             tmpNode = new TreeNode("Detail Level = Medium");
-            opts.DetailLevel = ViewDetailLevel.Medium;
-            tmpNode.Tag = elem.get_Geometry(opts);
-            rootNode.Nodes.Add(tmpNode);
+            geomOp.DetailLevel = ViewDetailLevel.Medium;
+            tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
+            rootNode1.Nodes.Add(tmpNode);
 
             tmpNode = new TreeNode("Detail Level = Fine");
-            opts.DetailLevel = ViewDetailLevel.Fine;
-            tmpNode.Tag = elem.get_Geometry(opts);
-            rootNode.Nodes.Add(tmpNode);
-         }
-
-         // now add geometry with the View set to the current view
-         if (elem.Document.ActiveView != null)
-         {
-            Options geomOp2 = m_app.Create.NewGeometryOptions();
-            geomOp2.ComputeReferences = true;
-            geomOp2.View = elem.Document.ActiveView;
-
-            TreeNode rootNode2 = new TreeNode("View = Document.ActiveView");
-            rootNode2.Tag = elem.get_Geometry(geomOp2);
-            curNodes.Add(rootNode2);
+            geomOp.DetailLevel = ViewDetailLevel.Fine;
+            tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
+            rootNode1.Nodes.Add(tmpNode);
 
             // SOFiSTiK FS
             // add model geometry including geometry objects not set as Visible.
             {
-               Autodesk.Revit.DB.Options opts = m_app.Create.NewGeometryOptions();
-               opts.ComputeReferences = true;
-               opts.IncludeNonVisibleObjects = true;
-               opts.View = elem.Document.ActiveView;
+                Autodesk.Revit.DB.Options opts = m_app.Create.NewGeometryOptions();
+                opts.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!;
+                opts.IncludeNonVisibleObjects = true;
 
-               TreeNode rootNode = new TreeNode("View = Document.ActiveView - Including geometry objects not set as Visible");
-               curNodes.Add(rootNode);
+                TreeNode rootNode = new TreeNode("View = null - Including geometry objects not set as Visible");
+                curNodes.Add(rootNode);
 
-               rootNode.Tag = elem.get_Geometry(opts);
+                tmpNode = new TreeNode("Detail Level = Undefined");
+                opts.DetailLevel = ViewDetailLevel.Undefined;
+                tmpNode.Tag = elem.GetOriginalGeometry(opts);
+                rootNode.Nodes.Add(tmpNode);
+
+                tmpNode = new TreeNode("Detail Level = Coarse");
+                opts.DetailLevel = ViewDetailLevel.Coarse;
+                tmpNode.Tag = elem.GetOriginalGeometry(opts);
+                rootNode.Nodes.Add(tmpNode);
+
+                tmpNode = new TreeNode("Detail Level = Medium");
+                opts.DetailLevel = ViewDetailLevel.Medium;
+                tmpNode.Tag = elem.GetOriginalGeometry(opts);
+                rootNode.Nodes.Add(tmpNode);
+
+                tmpNode = new TreeNode("Detail Level = Fine");
+                opts.DetailLevel = ViewDetailLevel.Fine;
+                tmpNode.Tag = elem.GetOriginalGeometry(opts);
+                rootNode.Nodes.Add(tmpNode);
             }
-         }
-      }
-   }
 
-
-
-
-   //SOFiSTiK FS
-
-   public class OriginalGeometry : RevitLookup.Snoop.Forms.ObjTreeBase
-   {
-      protected Element m_elem = null;
-      protected Autodesk.Revit.ApplicationServices.Application m_app = null;
-
-      public
-      OriginalGeometry(Autodesk.Revit.DB.FamilyInstance elem, Autodesk.Revit.ApplicationServices.Application app)
-      {
-         this.Text = "Element Original Geometry";
-
-         m_elem = elem;
-         m_app = app;
-
-         m_tvObjs.BeginUpdate();
-         AddObjectsToTree(elem, m_tvObjs.Nodes);
-         m_tvObjs.EndUpdate();
-      }
-
-      protected void
-      AddObjectsToTree(FamilyInstance elem, TreeNodeCollection curNodes)
-      {
-         Autodesk.Revit.DB.Options geomOp = m_app.Create.NewGeometryOptions();
-         geomOp.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!
-         TreeNode tmpNode;
-
-         // add geometry with the View set to null.
-         TreeNode rootNode1 = new TreeNode("View = null");
-         curNodes.Add(rootNode1);
-
-         tmpNode = new TreeNode("Detail Level = Undefined");
-         geomOp.DetailLevel = ViewDetailLevel.Undefined;
-         tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
-
-         tmpNode = new TreeNode("Detail Level = Coarse");
-         geomOp.DetailLevel = ViewDetailLevel.Coarse;
-         tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
-
-         tmpNode = new TreeNode("Detail Level = Medium");
-         geomOp.DetailLevel = ViewDetailLevel.Medium;
-         tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
-
-         tmpNode = new TreeNode("Detail Level = Fine");
-         geomOp.DetailLevel = ViewDetailLevel.Fine;
-         tmpNode.Tag = elem.GetOriginalGeometry(geomOp);
-         rootNode1.Nodes.Add(tmpNode);
-
-         // SOFiSTiK FS
-         // add model geometry including geometry objects not set as Visible.
-         {
-            Autodesk.Revit.DB.Options opts = m_app.Create.NewGeometryOptions();
-            opts.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!;
-            opts.IncludeNonVisibleObjects = true;
-
-            TreeNode rootNode = new TreeNode("View = null - Including geometry objects not set as Visible");
-            curNodes.Add(rootNode);
-
-            tmpNode = new TreeNode("Detail Level = Undefined");
-            opts.DetailLevel = ViewDetailLevel.Undefined;
-            tmpNode.Tag = elem.GetOriginalGeometry(opts);
-            rootNode.Nodes.Add(tmpNode);
-
-            tmpNode = new TreeNode("Detail Level = Coarse");
-            opts.DetailLevel = ViewDetailLevel.Coarse;
-            tmpNode.Tag = elem.GetOriginalGeometry(opts);
-            rootNode.Nodes.Add(tmpNode);
-
-            tmpNode = new TreeNode("Detail Level = Medium");
-            opts.DetailLevel = ViewDetailLevel.Medium;
-            tmpNode.Tag = elem.GetOriginalGeometry(opts);
-            rootNode.Nodes.Add(tmpNode);
-
-            tmpNode = new TreeNode("Detail Level = Fine");
-            opts.DetailLevel = ViewDetailLevel.Fine;
-            tmpNode.Tag = elem.GetOriginalGeometry(opts);
-            rootNode.Nodes.Add(tmpNode);
-         }
-
-         // now add geometry with the View set to the current view
-         if (elem.Document.ActiveView != null)
-         {
-            Options geomOp2 = m_app.Create.NewGeometryOptions();
-            geomOp2.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!;
-            geomOp2.View = elem.Document.ActiveView;
-
-            TreeNode rootNode2 = new TreeNode("View = Document.ActiveView");
-            rootNode2.Tag = elem.GetOriginalGeometry(geomOp2);
-            curNodes.Add(rootNode2);
-
-            // SOFiSTiK FS
-            // add model geometry including geometry objects not set as Visible.
+            // now add geometry with the View set to the current view
+            if (elem.Document.ActiveView != null)
             {
-               Autodesk.Revit.DB.Options opts = m_app.Create.NewGeometryOptions();
-               opts.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!;
-               opts.IncludeNonVisibleObjects = true;
-               opts.View = elem.Document.ActiveView;
+                Options geomOp2 = m_app.Create.NewGeometryOptions();
+                geomOp2.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!;
+                geomOp2.View = elem.Document.ActiveView;
 
-               TreeNode rootNode = new TreeNode("View = Document.ActiveView - Including geometry objects not set as Visible");
-               curNodes.Add(rootNode);
+                TreeNode rootNode2 = new TreeNode("View = Document.ActiveView");
+                rootNode2.Tag = elem.GetOriginalGeometry(geomOp2);
+                curNodes.Add(rootNode2);
 
-               rootNode.Tag = elem.GetOriginalGeometry(opts);
+                // SOFiSTiK FS
+                // add model geometry including geometry objects not set as Visible.
+                {
+                    Autodesk.Revit.DB.Options opts = m_app.Create.NewGeometryOptions();
+                    opts.ComputeReferences = false; // Not allowed for GetOriginalGeometry()!;
+                    opts.IncludeNonVisibleObjects = true;
+                    opts.View = elem.Document.ActiveView;
+
+                    TreeNode rootNode = new TreeNode("View = Document.ActiveView - Including geometry objects not set as Visible");
+                    curNodes.Add(rootNode);
+
+                    rootNode.Tag = elem.GetOriginalGeometry(opts);
+                }
             }
-         }
-      }
+        }
 
-   }
+    }
 }
 

--- a/CS/Snoop/Utils.cs
+++ b/CS/Snoop/Utils.cs
@@ -61,7 +61,7 @@ namespace RevitLookup.Snoop
                if (tmpSnoopData is Snoop.Data.ClassSeparator)
                   lvItem.BackColor = System.Drawing.Color.LightBlue;
                else
-                  lvItem.BackColor = System.Drawing.Color.Khaki;
+                  lvItem.BackColor = System.Drawing.Color.WhiteSmoke;
 
                lvItem.Tag = tmpSnoopData;
                lvCur.Items.Add(lvItem);


### PR DESCRIPTION
1) Methods and properties extraction. I changed it to get only public methods, declared only and sorted by name.
Before:
![image](https://cloud.githubusercontent.com/assets/2187260/23058707/14a0c81e-f518-11e6-8643-42e4198b5564.png)

After:
![image](https://cloud.githubusercontent.com/assets/2187260/23058709/1ae19b72-f518-11e6-82d6-ad001c9cd379.png)

 
2) Changed behavior how to show enum values.
Before:
![image](https://cloud.githubusercontent.com/assets/2187260/23058723/27684a62-f518-11e6-9cf2-08af858967cb.png)

After:
![image](https://cloud.githubusercontent.com/assets/2187260/23058725/2c88a582-f518-11e6-93c3-3d16eade6e4f.png)

 
 
3) Fixed the issue related with GeometryInstance.SymbolGeometry. We could not drill down this property.
Before:
![image](https://cloud.githubusercontent.com/assets/2187260/23058729/34185dec-f518-11e6-8607-668854af9eb6.png)

After:
![image](https://cloud.githubusercontent.com/assets/2187260/23058732/383f9a34-f518-11e6-9c92-30cb6f194172.png)
 
4) Removed property getter from the methods extraction. So for each property we saw method like get_SomeProperty:
Before:
![image](https://cloud.githubusercontent.com/assets/2187260/23058750/416edbd8-f518-11e6-8604-ff419d274d3d.png)

After:
![image](https://cloud.githubusercontent.com/assets/2187260/23058757/47e758aa-f518-11e6-8da1-787b8533448a.png)

 
5) Fixed the very old bug, related with geometry extraction. Whatever DetailLevel you select, it always showed the geometry for Fine DetailLevel.
For active view. MEdium DetailLevel
Before:
![image](https://cloud.githubusercontent.com/assets/2187260/23058766/50d60b6e-f518-11e6-9ad7-7af6aeb94082.png)

 
After:
![image](https://cloud.githubusercontent.com/assets/2187260/23058772/56349a9e-f518-11e6-8ac5-a0951b29ecfb.png)

 
 
6) Changed visual style of the separator. Changed color and shifted the title a bit.
Before:
![image](https://cloud.githubusercontent.com/assets/2187260/23058776/5d4f5224-f518-11e6-9842-56c0c3aaf16a.png)

After:
![image](https://cloud.githubusercontent.com/assets/2187260/23058781/62654eda-f518-11e6-89b6-85c4e60fb9ce.png)

 