### PR TITLE
Bugfixes and improvements

### DIFF
--- a/CS/Snoop/CollectorExts/DataTypeInfoHelper.cs
+++ b/CS/Snoop/CollectorExts/DataTypeInfoHelper.cs
@@ -71,7 +71,7 @@ namespace RevitLookup.Snoop.CollectorExts
                 }
                 else if (typeof(IEnumerable).IsAssignableFrom(expectedType))
                 {
-                    data.Add(new Snoop.Data.Enumerable(info.Name, returnValue as IEnumerable));
+                    data.Add(new Snoop.Data.Enumerable(info.Name, returnValue as IEnumerable, application.ActiveUIDocument.Document));
                 }
                 else if (expectedType.IsEnum)
                 {

--- a/CS/Snoop/CollectorExts/DataTypeInfoHelper.cs
+++ b/CS/Snoop/CollectorExts/DataTypeInfoHelper.cs
@@ -33,6 +33,12 @@ namespace RevitLookup.Snoop.CollectorExts
                     else
                         data.Add(new Snoop.Data.EmptyValue(info.Name));
                 }
+                else if (expectedType == typeof(byte))
+                {
+                    var value = (byte) returnValue;
+
+                    data.Add(new Snoop.Data.Int(info.Name, value));
+                }
                 else if ((expectedType == typeof(GeometryObject) || expectedType == typeof(GeometryElement)) && elem is Element)
                 {
                     data.Add(new Snoop.Data.ElementGeometry(info.Name, elem as Element, application.Application));

--- a/CS/Snoop/Data/Enumerable.cs
+++ b/CS/Snoop/Data/Enumerable.cs
@@ -69,11 +69,10 @@ namespace RevitLookup.Snoop.Data
                 IEnumerator iter = m_val.GetEnumerator();
                 while (iter.MoveNext())
                 {
-                    if (iter.Current is Autodesk.Revit.DB.ElementId)    // it's more useful for user to view element rather than element id.
-                    {
-                        Autodesk.Revit.DB.ElementId elemId = iter.Current as Autodesk.Revit.DB.ElementId;
-                        m_objs.Add(doc.GetElement(elemId));
-                    }
+                    var elementId = iter.Current as Autodesk.Revit.DB.ElementId;
+
+                    if (elementId != null && doc != null)
+                        m_objs.Add(doc.GetElement(elementId)); // it's more useful for user to view element rather than element id.
                     else
                         m_objs.Add(iter.Current);
                 }

--- a/CS/Snoop/Forms/Parameters.cs
+++ b/CS/Snoop/Forms/Parameters.cs
@@ -336,9 +336,11 @@ namespace RevitLookup.Snoop.Forms
 
                 // initialize the tree control
 			foreach (Parameter tmpObj in paramSet) {
-				TreeNode tmpNode = new TreeNode(tmpObj.Definition.Name);
-                tmpNode.Tag = tmpObj;
-                m_tvObjs.Nodes.Add(tmpNode);
+			    TreeNode tmpNode = new TreeNode(Utils.GetParameterObjectLabel(tmpObj))
+			        {
+			            Tag = tmpObj
+			        };
+			    m_tvObjs.Nodes.Add(tmpNode);
             }
         }
 
@@ -479,7 +481,7 @@ namespace RevitLookup.Snoop.Forms
                 if (tmpParam != null)
                 {
                     labelStrs.Add(str);
-                    valueStrs.Add(tmpParam.Definition.Name);
+                    valueStrs.Add(Utils.GetParameterObjectLabel(tmpParam));
                 }
             }
 


### PR DESCRIPTION
Hi, Jeremy!

Please, look at commits.

First of all, annotative families instances geometry can be explored now (for active view). Previously, it was "null" value in "Geometry" property for such families, because there is no model, but only view specific geometry.

Secondly, elements are displayed now for properties and methods with IEnumerable<ElementId> return value, such as Element.GetValidTypes() or ElementType.GetSimilarTypes() instead of ElementIds

Thirdly, parameters names are displayed in the left pane in all cases, not only for Element.Parameters property

And small improvement - now byte properties are displayed as number instead of "<Byte>"