### PR TITLE
Update link to RevitLookup .msi

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Harry Mattison of [Boost your BIM](https://boostyourbim.wordpress.com) very kind
 a ready-built [RevitLookup 2018 installer](https://boostyourbim.wordpress.com/2017/04/28/revit-lookup-2018-install):
 
 > If you don’t want to deal with source code and just want to use the tool, here
-is [Revit Lookup 2018.msi](https://drive.google.com/open?id=0BwszsfY3OsZHbGNrSkFEOHhRX0E),
+is [Revit Lookup 2018.msi](https://drive.google.com/open?id=182W00Mk5Hj1FMHAo-xVnoFYlJ_s2Swrw),
 an installer for the compiled and signed DLL ready, courtesy of Boost Your BIM.
 
 <a name="caveat"></a>


### PR DESCRIPTION
Harry has updated the Google Drive link to the .msi.  You can verify the authenticity of this new URL here: https://boostyourbim.wordpress.com/2017/04/28/revit-lookup-2018-install/.