### PR TITLE
Add "Search by and snoop" command

### DIFF
--- a/CS/App.cs
+++ b/CS/App.cs
@@ -35,83 +35,84 @@ using Autodesk.Revit.UI;
 namespace RevitLookup
 {
 
-  [Transaction( TransactionMode.Manual )]
-  [Regeneration( RegenerationOption.Manual )]
-  public class App : IExternalApplication
-  {
-    static AddInId m_appId = new AddInId( new Guid( 
-      "356CDA5A-E6C5-4c2f-A9EF-B3222116B8C8" ) );
-
-    // get the absolute path of this assembly
-    static string ExecutingAssemblyPath = System.Reflection.Assembly
-      .GetExecutingAssembly().Location;
-
-    private AppDocEvents m_appDocEvents;
-
-    public Result OnStartup( 
-      UIControlledApplication application )
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class App : IExternalApplication
     {
+        static AddInId m_appId = new AddInId(new Guid(
+          "356CDA5A-E6C5-4c2f-A9EF-B3222116B8C8"));
 
-      // Call this method explicitly in App.cs when Revit starts up because,
-      // in .NET 4, the static variables will not be initialized until use them.
-      Snoop.Collectors.CollectorObj.InitializeCollectors();
-      AddMenu( application );
-      AddAppDocEvents( application.ControlledApplication );
+        // get the absolute path of this assembly
+        static string ExecutingAssemblyPath = System.Reflection.Assembly
+          .GetExecutingAssembly().Location;
 
-      return Result.Succeeded;
+        private AppDocEvents m_appDocEvents;
+
+        public Result OnStartup(
+          UIControlledApplication application)
+        {
+
+            // Call this method explicitly in App.cs when Revit starts up because,
+            // in .NET 4, the static variables will not be initialized until use them.
+            Snoop.Collectors.CollectorObj.InitializeCollectors();
+            AddMenu(application);
+            AddAppDocEvents(application.ControlledApplication);
+
+            return Result.Succeeded;
+        }
+
+        public Result OnShutdown(
+          UIControlledApplication application)
+        {
+            RemoveAppDocEvents();
+
+            return Result.Succeeded;
+        }
+
+        private void AddMenu(UIControlledApplication app)
+        {
+            RibbonPanel rvtRibbonPanel = app.CreateRibbonPanel("Revit Lookup");
+            PulldownButtonData data = new PulldownButtonData("Options", "Revit Lookup");
+
+            RibbonItem item = rvtRibbonPanel.AddItem(data);
+            PulldownButton optionsBtn = item as PulldownButton;
+
+            // Add Icons to main RevitLookup Menu
+            optionsBtn.Image = GetEmbeddedImage("RevitLookup.Resources.RLookup-16.png");
+            optionsBtn.LargeImage = GetEmbeddedImage("RevitLookup.Resources.RLookup-32.png");
+
+            optionsBtn.AddPushButton(new PushButtonData("HelloWorld", "Hello World...", ExecutingAssemblyPath, "RevitLookup.HelloWorld"));
+            optionsBtn.AddPushButton(new PushButtonData("Snoop Db..", "Snoop DB...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopDb"));
+            optionsBtn.AddPushButton(new PushButtonData("Snoop Current Selection...", "Snoop Current Selection...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopModScope"));
+            optionsBtn.AddPushButton(new PushButtonData("Snoop Active View...", "Snoop Active View...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopActiveView"));
+            optionsBtn.AddPushButton(new PushButtonData("Snoop Application...", "Snoop Application...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopApp"));
+            optionsBtn.AddPushButton(new PushButtonData("Search and Snoop...", "Search and Snoop...", ExecutingAssemblyPath, "RevitLookup.CmdSearchBy"));
+            optionsBtn.AddPushButton(new PushButtonData("Test Framework...", "Test Framework...", ExecutingAssemblyPath, "RevitLookup.CmdTestShell"));
+        }
+
+        private void AddAppDocEvents(ControlledApplication app)
+        {
+            m_appDocEvents = new AppDocEvents(app);
+            m_appDocEvents.EnableEvents();
+        }
+
+        private void RemoveAppDocEvents()
+        {
+            m_appDocEvents.DisableEvents();
+        }
+
+        static BitmapSource GetEmbeddedImage(string name)
+        {
+            try
+            {
+                Assembly a = Assembly.GetExecutingAssembly();
+                Stream s = a.GetManifestResourceStream(name);
+                return BitmapFrame.Create(s);
+            }
+            catch
+            {
+                return null;
+            }
+        }
     }
-
-    public Result OnShutdown( 
-      UIControlledApplication application )
-    {
-      RemoveAppDocEvents();
-
-      return Result.Succeeded;
-    }
-
-    private void AddMenu( UIControlledApplication app )
-    {
-      RibbonPanel rvtRibbonPanel = app.CreateRibbonPanel( "Revit Lookup" );
-      PulldownButtonData data = new PulldownButtonData( "Options", "Revit Lookup" );
-
-      RibbonItem item = rvtRibbonPanel.AddItem( data );
-      PulldownButton optionsBtn = item as PulldownButton;
-
-      // Add Icons to main RevitLookup Menu
-      optionsBtn.Image = GetEmbeddedImage("RevitLookup.Resources.RLookup-16.png");
-      optionsBtn.LargeImage = GetEmbeddedImage("RevitLookup.Resources.RLookup-32.png");
-
-      optionsBtn.AddPushButton( new PushButtonData( "HelloWorld", "Hello World...", ExecutingAssemblyPath, "RevitLookup.HelloWorld" ) );
-      optionsBtn.AddPushButton( new PushButtonData( "Snoop Db..", "Snoop DB...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopDb" ) );
-      optionsBtn.AddPushButton( new PushButtonData( "Snoop Current Selection...", "Snoop Current Selection...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopModScope" ) );
-      optionsBtn.AddPushButton( new PushButtonData( "Snoop Active View...", "Snoop Active View...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopActiveView" ) );
-      optionsBtn.AddPushButton( new PushButtonData( "Snoop Application...", "Snoop Application...", ExecutingAssemblyPath, "RevitLookup.CmdSnoopApp" ) );
-      optionsBtn.AddPushButton( new PushButtonData( "Test Framework...", "Test Framework...", ExecutingAssemblyPath, "RevitLookup.CmdTestShell" ) );
-    }
-
-    private void AddAppDocEvents( ControlledApplication app )
-    {
-      m_appDocEvents = new AppDocEvents( app );
-      m_appDocEvents.EnableEvents();
-    }
-
-    private void RemoveAppDocEvents()
-    {
-      m_appDocEvents.DisableEvents();
-    }
-
-    static BitmapSource GetEmbeddedImage(string name)
-    {
-      try
-      {
-        Assembly a = Assembly.GetExecutingAssembly();
-        Stream s = a.GetManifestResourceStream(name);
-        return BitmapFrame.Create(s);
-      }
-      catch
-      {
-        return null;
-      }
-    }
-  }
 }

--- a/CS/RevitLookup.csproj
+++ b/CS/RevitLookup.csproj
@@ -319,6 +319,12 @@
     <Compile Include="Snoop\Forms\Parameters.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Snoop\Forms\SearchBy.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Snoop\Forms\SearchBy.Designer.cs">
+      <DependentUpon>SearchBy.cs</DependentUpon>
+    </Compile>
     <Compile Include="Snoop\Utils.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -367,6 +373,9 @@
     <EmbeddedResource Include="Snoop\Forms\Parameters.resx">
       <DependentUpon>Parameters.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Snoop\Forms\SearchBy.resx">
+      <DependentUpon>SearchBy.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Xml\Forms\Dom.resx">
       <DependentUpon>Dom.cs</DependentUpon>

--- a/CS/Snoop/Forms/SearchBy.Designer.cs
+++ b/CS/Snoop/Forms/SearchBy.Designer.cs
@@ -1,0 +1,112 @@
+﻿namespace RevitLookup.Snoop.Forms
+{
+    partial class SearchBy
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.m_cbSearchByVariant = new System.Windows.Forms.ComboBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.m_tbSearchValue = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.m_bnFindAndSnoop = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // m_cbSearchByVariant
+            // 
+            this.m_cbSearchByVariant.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.m_cbSearchByVariant.FormattingEnabled = true;
+            this.m_cbSearchByVariant.Items.AddRange(new object[] {
+            "ElementId",
+            "UniqId"});
+            this.m_cbSearchByVariant.Location = new System.Drawing.Point(117, 12);
+            this.m_cbSearchByVariant.Name = "m_cbSearchByVariant";
+            this.m_cbSearchByVariant.Size = new System.Drawing.Size(255, 21);
+            this.m_cbSearchByVariant.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 15);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(58, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Search by:";
+            // 
+            // m_tbSearchValue
+            // 
+            this.m_tbSearchValue.Location = new System.Drawing.Point(117, 39);
+            this.m_tbSearchValue.Name = "m_tbSearchValue";
+            this.m_tbSearchValue.Size = new System.Drawing.Size(255, 20);
+            this.m_tbSearchValue.TabIndex = 2;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 43);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(99, 13);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Value to search for:";
+            // 
+            // m_bnFindAndSnoop
+            // 
+            this.m_bnFindAndSnoop.Location = new System.Drawing.Point(117, 76);
+            this.m_bnFindAndSnoop.Name = "m_bnFindAndSnoop";
+            this.m_bnFindAndSnoop.Size = new System.Drawing.Size(100, 23);
+            this.m_bnFindAndSnoop.TabIndex = 4;
+            this.m_bnFindAndSnoop.Text = "Find and snoop";
+            this.m_bnFindAndSnoop.UseVisualStyleBackColor = true;
+            this.m_bnFindAndSnoop.Click += new System.EventHandler(this.m_bnFindAndSnoop_Click);
+            // 
+            // SearchBy
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(384, 111);
+            this.Controls.Add(this.m_bnFindAndSnoop);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.m_tbSearchValue);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.m_cbSearchByVariant);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Name = "SearchBy";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "SearchBy";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ComboBox m_cbSearchByVariant;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox m_tbSearchValue;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Button m_bnFindAndSnoop;
+    }
+}

--- a/CS/Snoop/Forms/SearchBy.cs
+++ b/CS/Snoop/Forms/SearchBy.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using Autodesk.Revit.DB;
+using Form = System.Windows.Forms.Form;
+
+namespace RevitLookup.Snoop.Forms
+{
+    public partial class SearchBy : Form
+    {
+        private readonly Document _doc;
+
+        public SearchBy(Document doc)
+        {
+            InitializeComponent();
+            m_cbSearchByVariant.SelectedIndex = 0;
+            _doc = doc;
+        }
+
+        private void m_bnFindAndSnoop_Click(object sender, System.EventArgs e)
+        {
+            if (string.IsNullOrEmpty(m_tbSearchValue.Text))
+            {
+                MessageBox.Show(@"You did not enter a value to search for", @"Attention!", MessageBoxButtons.OK,
+                    MessageBoxIcon.Stop);
+            }
+            switch (m_cbSearchByVariant.SelectedItem)
+            {
+                case "ElementId": // by ElementId
+                    SearcAndSnoopByElementId();
+                    break;
+                case "UniqId": // by UniqId
+                    SearchAndSnoopByUniqId();
+                    break;
+            }
+        }
+
+        private void SearcAndSnoopByElementId()
+        {
+            if (int.TryParse(m_tbSearchValue.Text, out var id))
+            {
+                FilteredElementCollector elemTypeCtor = (new FilteredElementCollector(_doc)).WhereElementIsElementType();
+                FilteredElementCollector notElemTypeCtor = (new FilteredElementCollector(_doc)).WhereElementIsNotElementType();
+                FilteredElementCollector allElementCtor = elemTypeCtor.UnionWith(notElemTypeCtor);
+                ICollection<ElementId> ids = allElementCtor
+                    .Where(el => el.Id.IntegerValue == id).Select(el => el.Id).ToList();
+                if (ids.Count != 0)
+                {
+                    Snoop.Forms.Objects form = new Snoop.Forms.Objects(_doc, ids);
+                    form.ShowDialog();
+                }
+                else
+                    MessageBox.Show($@"No items with ID {id} found");
+            }
+            else
+                MessageBox.Show(@"The ID value must represent an integer value");
+        }
+
+        private void SearchAndSnoopByUniqId()
+        {
+            FilteredElementCollector elemTypeCtor = (new FilteredElementCollector(_doc)).WhereElementIsElementType();
+            FilteredElementCollector notElemTypeCtor = (new FilteredElementCollector(_doc)).WhereElementIsNotElementType();
+            FilteredElementCollector allElementCtor = elemTypeCtor.UnionWith(notElemTypeCtor);
+            ICollection<ElementId> ids = allElementCtor
+                .Where(el => el.UniqueId == m_tbSearchValue.Text).Select(el => el.Id).ToList();
+            if (ids.Count != 0)
+            {
+                Snoop.Forms.Objects form = new Snoop.Forms.Objects(_doc, ids);
+                form.ShowDialog();
+            }
+            else
+                MessageBox.Show($@"No items with ID {m_tbSearchValue.Text} found");
+        }
+    }
+}

--- a/CS/Snoop/Forms/SearchBy.resx
+++ b/CS/Snoop/Forms/SearchBy.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/CS/TestCmds.cs
+++ b/CS/TestCmds.cs
@@ -31,6 +31,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Autodesk.Revit.Attributes;
 using System.Reflection;
+using RevitLookup.Snoop.Forms;
 
 // Each command is implemented as a class that provides the IExternalCommand Interface
 //
@@ -258,6 +259,40 @@ namespace RevitLookup
             try
             {
                 MessageBox.Show("Called back into RevitLookup by picking toolbar or menu item");
+                result = Result.Succeeded;
+            }
+            catch (System.Exception e)
+            {
+                msg = e.Message;
+                result = Result.Failed;
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Search by and Snoop command: Browse elements found by the condition
+    /// </summary>
+
+    [Transaction(TransactionMode.Manual)]
+    [Regeneration(RegenerationOption.Manual)]
+    public class CmdSearchBy : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData cmdData, ref string msg, ElementSet elems)
+        {
+            Result result;
+
+            try
+            {
+                Snoop.CollectorExts.CollectorExt.m_app = cmdData.Application;
+                UIDocument revitDoc = cmdData.Application.ActiveUIDocument;
+                Document dbdoc = revitDoc.Document;
+                Snoop.CollectorExts.CollectorExt.m_activeDoc = dbdoc; // TBD: see note in CollectorExt.cs
+                
+                SearchBy searchByWin = new SearchBy(dbdoc);
+                ActiveDoc.UIApp = cmdData.Application;
+                searchByWin.ShowDialog();
                 result = Result.Succeeded;
             }
             catch (System.Exception e)


### PR DESCRIPTION
Add "Search by and snoop" command that allows you to search and snoop for elements by condition.
![screenshot_6](https://user-images.githubusercontent.com/12638819/37233189-4974e4d8-2403-11e8-880d-7bca3d320c46.png)
![screenshot_7](https://user-images.githubusercontent.com/12638819/37233210-5e0ec9f4-2403-11e8-9403-2ad042b79ee8.png)
A small addition to the project: search for items by ElementId or UniqId and then snoop them.
Search options made in the form of a drop-down list for the possibility of further expansion (for example, search by parameters or something similar).
This view option can be useful for developers who receive an ElementId while debugging an application and need to learn about it later in Revit