### PR TITLE
Move CI to gitlab.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,108 @@
+stages:
+  - download-revit-api
+  - build
+  - sign
+  - publish
+
+download-revit-api:
+  stage: download-revit-api
+  image: alpine:3.12
+  variables:
+    REVIT_API_URL: https://bimag.b-cdn.net/revit/2019/RevitAPI.dll
+    REVIT_API_CHECKSUM: da1fbac1e5afb210478cbb508e0677679e994da8c9e13b56c43d5e122dabd6e7
+    REVIT_APIUI_URL: https://bimag.b-cdn.net/revit/2019/RevitAPIUI.dll
+    REVIT_APIUI_CHECKSUM: d29a755922997310a215afa83fa44ea91aafdd6feddce722e5feed98d2ae9f73
+  script:
+    - apk add --update --no-cache curl
+    - mkdir revit-api
+    - |
+        echo "${REVIT_API_CHECKSUM}  -" > /tmp/checksum \
+        && curl -L "${REVIT_API_URL}" \
+        | tee revit-api/RevitAPI.dll \
+        | sha256sum -c /tmp/checksum
+    - |
+        echo "${REVIT_APIUI_CHECKSUM}  -" > /tmp/checksum \
+        && curl -L "${REVIT_APIUI_URL}" \
+        | tee revit-api/RevitAPIUI.dll \
+        | sha256sum -c /tmp/checksum
+  artifacts:
+    paths:
+      - revit-api/
+    expire_in: 1 day
+
+build:
+  stage: build
+  tags:
+    - shared-windows
+    - windows
+    - windows-1809
+  dependencies:
+    - download-revit-api
+  variables:
+    MSBUILD: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe'
+  script:
+    - '& "$MSBUILD" -p:TargetFrameworkVersion=v4.7.2 -p:Configuration=2021 -p:ReferencePath="../revit-api" -p:PostBuildEvent= CS/RevitLookup.sln'
+    - New-Item -Force -ItemType Directory -Path artifacts | Out-Null
+    - Copy-Item "CS/bin/2021/RevitLookup.dll" artifacts/
+    - Copy-Item "CS/RevitLookup.addin" artifacts/
+  artifacts:
+    paths:
+      - artifacts/
+    expire_in: 1 day
+
+sign:
+  stage: sign
+  image: debian:buster-slim
+  dependencies:
+    - build
+  variables:
+    ASSEMBLY: artifacts/RevitLookup.dll
+    TIMESERVER: http://timestamp.verisign.com/scripts/timstamp.dll
+    DEBIAN_FRONTEND: noninteractive
+  script:
+    - apt-get update && apt-get install -y --no-install-recommends osslsigncode
+    - mkdir -p .secrets && mount -t ramfs -o size=1M ramfs .secrets/
+    - echo "${CODESIGN_CERTIFICATE}" | base64 --decode > .secrets/authenticode.spc
+    - echo "${CODESIGN_KEY}" | base64 --decode > .secrets/authenticode.key
+    - osslsigncode -h sha1 -spc .secrets/authenticode.spc -key .secrets/authenticode.key -t ${TIMESERVER} -in "${ASSEMBLY}" -out "${ASSEMBLY}-sha1"
+    - osslsigncode -nest -h sha2 -spc .secrets/authenticode.spc -key .secrets/authenticode.key -t ${TIMESERVER} -in "${ASSEMBLY}-sha1" -out "${ASSEMBLY}"
+    - rm "${ASSEMBLY}-sha1"
+  after_script:
+    - rmdir .secrets
+  artifacts:
+    paths:
+      - artifacts/
+    expire_in: 1 day
+  only:
+    variables:
+      - $CODESIGN_CERTIFICATE != null
+      - $CODESIGN_KEY != null
+
+publish:
+  stage: publish
+  image: alpine:3.12
+  dependencies:
+    - sign
+  before_script:
+    - |
+        if [ -n "${CI_COMMIT_TAG}" ]; then
+            export RELEASE_NAME="${CI_COMMIT_TAG}"
+            export S3_FOLDER="releases"
+        else
+            export RELEASE_NAME="${CI_COMMIT_BRANCH}-$(date --utc -Iseconds)"
+            export S3_FOLDER="current"
+        fi
+    - export ZIP="${RELEASE_NAME}.7z"
+
+    - apk add --update --no-cache curl jq py-pip p7zip
+    - pip install awscli
+    - eval $(aws ecr get-login --no-include-email --region $AWS_REGION | sed 's|https://||')
+  script:
+    - 7z a "${ZIP}" ./artifacts/*
+    - aws s3 cp "${ZIP}" "s3://${S3_BUCKET_NAME}/${S3_FOLDER}/${ZIP}"
+  only:
+    variables:
+      - $AWS_ACCESS_KEY_ID != null
+      - $AWS_SECRET_ACCESS_KEY != null
+      - $AWS_REGION != null
+      - $S3_BUCKET_NAME != null

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Platform](https://img.shields.io/badge/platform-Windows-lightgray.svg)
 ![.NET](https://img.shields.io/badge/.NET-4.8-blue.svg)
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://opensource.org/licenses/MIT)
-[![Build Status](https://s3-eu-west-1.amazonaws.com/lookup-builds/extra/build_status.svg)](https://lookupbuilds.com)
+[![Build Status](https://gitlab.com/buildinformed-public/revitlookup/badges/master/pipeline.svg)](https://lookupbuilds.com)
 
 Interactive Revit BIM database exploration tool to view and navigate element properties and relationships.
 
@@ -28,19 +28,14 @@ If you are interested in an earlier release of Revit, please grab the latest app
 
 ## <a name="builds"></a> Builds
 
-Peter Hirn of [Build Informed GmbH](https://www.buildinformed.com) very kindly set up a
+[Build Informed GmbH](https://www.buildinformed.com) very kindly set up a
 public [CI](https://en.wikipedia.org/wiki/Continuous_integration) for RevitLookup
 at [lookupbuilds.com](https://lookupbuilds.com)
-using [Jenkins](https://jenkins.io/index.html) in
-a multi-branch project configuration to build all branches and tags from the GitHub repository.
+using [gitlab.com](https://gitlab.com).
 The output is dual-signed with the Build Informed certificate, zipped and published to an Amazon S3 bucket.
-For more information, please refer to 
+For more information, please refer to
 the [Revit API discussion forum](http://forums.autodesk.com/t5/revit-api-forum/bd-p/160) thread
 on [CI for RevitLookup](https://forums.autodesk.com/t5/revit-api-forum/ci-for-revit-lookup/m-p/6947111).
-
-Peter also added the build status badge at the top of this page.
-
-Thank you very much, Peter!
 
 
 ## Installation
@@ -84,7 +79,7 @@ Says he:
 <a name="caveat"></a>
 ## Caveat &ndash; RevitLookup Cannot Snoop Everything
 
-This clarification was prompted by 
+This clarification was prompted by
 the [issue #35 &ndash; RevitLookup doesn't snoop all members](https://github.com/jeremytammik/RevitLookup/issues/35):
 
 **Question:** I tried snooping a selected Structural Rebar element in the active view and found not all of the Rebar class members showed up in the Snoop Objects window. One of many members that weren't there: `Rebar.GetFullGeometryForView` method.


### PR DESCRIPTION
Hey Jeremy!

I moved the CI to gitlab.com. The entire pipeline to build and publish RevitLookup is now defined in `.gitlab-ci.yml`.

You can check out the progress and output of the CI at https://gitlab.com/buildinformed-public/revitlookup/-/pipelines.

Once you accept this merge request, the build should be triggered after max. 30 (?) minutes.

As you can see in the `build` stage I'm still building against Revit 2019 API and force the framework version to v4.7.2. If there is a problem developers can try to fix it by editing this file or contact us (eg. info@buildinformed.com).

Have a nice weekend!