### PR TITLE
Update timestamp server from Verisign to digicert

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ sign:
     - build
   variables:
     ASSEMBLY: artifacts/RevitLookup.dll
-    TIMESERVER: http://timestamp.verisign.com/scripts/timstamp.dll
+    TIMESERVER: http://timestamp.digicert.com
     DEBIAN_FRONTEND: noninteractive
     GIT_STRATEGY: none
   script:


### PR DESCRIPTION
Verisign disabled their timestamp server, see https://stackoverflow.com/questions/65541786/is-the-verisign-timestamp-server-down.

I was able to override the faulty value with a global CI variable and rebuilt the current release (2021.0.0.10). A release for this PR is not required.