### PR TITLE
Extensible storage lookup fix and small improvements

### DIFF
--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Linq;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using RevitLookup.Snoop.Collectors;
@@ -52,6 +53,7 @@ namespace RevitLookup.Snoop.CollectorExts
                 .Where(x => Path.GetDirectoryName(x.Location) == baseDirectory)
                 .Where(x => x.GetName().Name.ToLower().Contains("revit"))
                 .SelectMany(x => x.GetTypes())
+                .Union(new [] {typeof(KeyValuePair<,>)})
                 .ToArray();
         }
 
@@ -72,7 +74,7 @@ namespace RevitLookup.Snoop.CollectorExts
 
         private void Stream(ArrayList data, object elem)
         {
-            var thisElementTypes = types.Where(x => elem.GetType().IsSubclassOf(x) || elem.GetType() == x || x.IsAssignableFrom(elem.GetType())).ToList();
+            var thisElementTypes = types.Where(x => IsSnoopableType(x, elem)).ToList();
 
             var streams = new IElementStream[]
                 {
@@ -83,9 +85,9 @@ namespace RevitLookup.Snoop.CollectorExts
                     new ExtensibleStorageEntityContentStream(m_app.ActiveUIDocument.Document, data, elem)
                 };
 
-            foreach (Type type in thisElementTypes)
+            foreach (var type in thisElementTypes)
             {
-                data.Add(new Snoop.Data.ClassSeparator(type));
+                data.Add(new ClassSeparator(type));
 
                 foreach (var elementStream in streams)
                     elementStream.Stream(type);
@@ -96,6 +98,27 @@ namespace RevitLookup.Snoop.CollectorExts
             StreamSimpleType(data, elem);
         }
 
+        private static bool IsSnoopableType(Type type, object element)
+        {
+            var elementType = element.GetType();
+
+            if (type == elementType || elementType.IsSubclassOf(type) || type.IsAssignableFrom(elementType))
+                return true;
+            
+            return type.IsGenericType && elementType.IsGenericType && IsSubclassOfRawGeneric(type, elementType);
+        }
+        
+        private static bool IsSubclassOfRawGeneric(Type generic, Type toCheck) {
+            while (toCheck != null && toCheck != typeof(object)) {
+                var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
+                if (generic == cur) {
+                    return true;
+                }
+                toCheck = toCheck.BaseType;
+            }
+            return false;
+        }
+        
         private static void StreamElementExtensibleStorages(ArrayList data, Element elem)
         {
             var schemas = Schema.ListSchemas();

--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -32,7 +32,6 @@ using RevitLookup.Snoop.Collectors;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.ExtensibleStorage;
 using RevitLookup.Snoop.Data;
-using String = System.String;
 
 namespace RevitLookup.Snoop.CollectorExts
 {

--- a/CS/Snoop/CollectorExts/DataFactory.cs
+++ b/CS/Snoop/CollectorExts/DataFactory.cs
@@ -17,8 +17,13 @@ namespace RevitLookup.Snoop.CollectorExts
             this.elem = elem;
         }
 
-        public Data.Data Create(MethodInfo methodInfo)
+        public Data.Data Create(MethodInfo mi)
         {
+            var methodInfo = mi.ContainsGenericParameters ? elem.GetType().GetMethod(mi.Name, mi.GetParameters().Select(x => x.ParameterType).ToArray()) : mi;
+
+            if (methodInfo == null)
+                return null;
+            
             var declaringType = methodInfo.DeclaringType;
 
             if (methodInfo.IsSpecialName || declaringType == null)

--- a/CS/Snoop/CollectorExts/ExtensibleStorageEntityContentStream.cs
+++ b/CS/Snoop/CollectorExts/ExtensibleStorageEntityContentStream.cs
@@ -54,7 +54,7 @@ namespace RevitLookup.Snoop.CollectorExts
 
             var fieldSpecType = field.GetSpecTypeId();
 
-            var unit = UnitUtils.IsMeasurableSpec(fieldSpecType) ? UnitUtils.GetValidUnits(field.GetSpecTypeId()).First() : null;
+            var unit = UnitUtils.IsMeasurableSpec(fieldSpecType) ? UnitUtils.GetValidUnits(field.GetSpecTypeId()).First() : UnitTypeId.Custom;
 
             var parameters = getEntityValueMethod.GetParameters().Length == 1
                 ? new object[] {field}
@@ -139,7 +139,7 @@ namespace RevitLookup.Snoop.CollectorExts
         
         var fieldSpecType = field.GetSpecTypeId();
 
-        if (UnitUtils.IsMeasurableSpec(fieldSpecType))
+        if (UnitUtils.IsMeasurableSpec(fieldSpecType) || fieldSpecType == SpecTypeId.Custom)
         {
             var firstParameter = parameters.First();
 

--- a/CS/Snoop/CollectorExts/ExtensibleStorageEntityContentStream.cs
+++ b/CS/Snoop/CollectorExts/ExtensibleStorageEntityContentStream.cs
@@ -97,7 +97,7 @@ namespace RevitLookup.Snoop.CollectorExts
       try
       {
         if( field.ContainerType != ContainerType.Simple )
-          data.Add( new Snoop.Data.Object( field.FieldName, value ) );
+          data.Add( new Snoop.Data.Enumerable( field.FieldName, value as IEnumerable ) );
         else if( field.ValueType == typeof( double ) )
           data.Add( new Snoop.Data.Double( field.FieldName, (double) value ) );
         else if( field.ValueType == typeof( string ) )

--- a/CS/Snoop/Data/ElementId.cs
+++ b/CS/Snoop/Data/ElementId.cs
@@ -22,63 +22,44 @@
 //
 #endregion // Header
 
-using System;
-using System.Windows.Forms;
-using System.Collections;
-
 using Autodesk.Revit.DB;
 
 namespace RevitLookup.Snoop.Data
 {
-	/// <summary>
-	/// Snoop.Data class to hold and format an ElementId value.
-	/// </summary>
-	
-	public class ElementId : Data
-	{
-	    protected Autodesk.Revit.DB.ElementId	m_val;
-		protected Element	m_elem = null;
-	    
-		public
-		ElementId(string label, Autodesk.Revit.DB.ElementId val, Document doc)
-		:   base(label)
-		{
-		   m_val = val;
-         try
-         {
-            if (val != Autodesk.Revit.DB.ElementId.InvalidElementId)
-               m_elem = doc.GetElement(val);	// TBD: strange signature!
-         }
-         catch (System.Exception)
-         {
-            m_elem = null;
-         }
-		}
-		
-        public override string
-        StrValue()
+    /// <summary>
+    /// Snoop.Data class to hold and format an ElementId value.
+    /// </summary>
+
+    public class ElementId : Data
+    {
+        protected Autodesk.Revit.DB.ElementId m_val;
+        protected Element m_elem;
+
+        public ElementId(string label, Autodesk.Revit.DB.ElementId val, Document doc) : base(label)
         {
-			return Utils.ObjToLabelStr(m_elem);
+            m_val = val;
+            
+            m_elem = doc.GetElement(val);
         }
-        
-        public override bool
-        HasDrillDown
+
+        public override string StrValue()
         {
-            get {
-                if (m_elem == null)
-                    return false;
-                else
-                    return true;
-            }
+            if (m_elem != null)
+                return Utils.ObjToLabelStr(m_elem);
+
+            return m_val != Autodesk.Revit.DB.ElementId.InvalidElementId ? m_val.ToString() : Utils.ObjToLabelStr(null);
         }
-        
-        public override void
-        DrillDown()
+
+        public override bool HasDrillDown => m_elem != null;
+
+        public override void DrillDown()
         {
-            if (m_elem != null) {
-				Snoop.Forms.Objects form = new Snoop.Forms.Objects(m_elem);
-				form.ShowDialog();
-			}
+            if (m_elem == null) 
+                return;
+            
+            var form = new Forms.Objects(m_elem);
+            
+            form.ShowDialog();
         }
-	}
+    }
 }

--- a/CS/Snoop/Data/Enumerable.cs
+++ b/CS/Snoop/Data/Enumerable.cs
@@ -71,7 +71,7 @@ namespace RevitLookup.Snoop.Data
                 {
                     var elementId = iter.Current as Autodesk.Revit.DB.ElementId;
 
-                    if (elementId != null && doc != null)
+                    if (elementId != null && doc != null && elementId.IntegerValue > 0)
                         m_objs.Add(doc.GetElement(elementId)); // it's more useful for user to view element rather than element id.
                     else
                         m_objs.Add(iter.Current);


### PR DESCRIPTION
Hi, Jeremy!

I've fixed the app for Extensible storages. Extensible storage fields were broken:
![изображение](https://user-images.githubusercontent.com/14212214/118660808-33469180-b7f7-11eb-93c1-91a216e35ed4.png)

Now RevitLookup also supports Dictionary KeyValuePairs lookup. It is also useful to view extensible storage entities data:
![изображение](https://user-images.githubusercontent.com/14212214/118661293-a6500800-b7f7-11eb-943a-d4bda486f046.png)

Plus a small improvement. ElementId could be a model element id, a built-in parameter or built-in-category. For the last two it is much more useful to see an integer value instead of "< null >"