### PR TITLE
Update global.json support beta version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2022-01-15 **2022.0.3.3** BindingMap support. https://github.com/jeremytammik/RevitLookup/issues/128 issue.
 - 2022-01-03 **2022.0.3.2** This update fixes the display of labels:
   - Support for string empty label.
   - Support for string null label.

--- a/RevitLookup/RevitLookup.csproj
+++ b/RevitLookup/RevitLookup.csproj
@@ -13,7 +13,6 @@
     <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
     </PropertyGroup>
     <PropertyGroup Condition="$(Configuration.Contains('Release'))">
         <Optimize>true</Optimize>

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "6.0.0",
     "rollForward": "latestMinor",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
# Summary of the Pull Request
Allow preview release .NET 6
**What is this about:**: Change global json supprot beta version
# Description  
Dear @Nice3point, 
whether we can change to support a beta version, at the moment,I'm using a beta version to working with visual studio 2022
