### PR TITLE
Improve show detail sub tree view support search index from keyboard

### DIFF
--- a/RevitLookup/Core/Utils.cs
+++ b/RevitLookup/Core/Utils.cs
@@ -135,7 +135,7 @@ public static class Utils
 
         if (nameProperty is null) return null;
         var propertyValue = nameProperty.GetValue(obj) as string;
-        return $"< {obj.GetType().Name}  {(string.IsNullOrEmpty(propertyValue) ? Labels.Undefined : propertyValue)} >";
+        return $"{obj.GetType().Name}  {(string.IsNullOrEmpty(propertyValue) ? Labels.Undefined : propertyValue)}";
     }
 
     public static string GetParameterObjectLabel(object obj)
@@ -165,14 +165,14 @@ public static class Utils
                 try
                 {
                     var nameStr = elem.Name == string.Empty ? Labels.Undefined : elem.Name;
-                    return $"< {nameStr}  {elem.Id.IntegerValue} >";
+                    return $"{nameStr}  {elem.Id.IntegerValue}";
                 }
                 catch (Exception ex)
                 {
-                    return $"< {null}  {ex.Message} >";
+                    return $"{null}  {ex.Message}";
                 }
             default:
-                return GetNamedObjectLabel(obj) ?? GetParameterObjectLabel(obj) ?? GetFamilyParameterObjectLabel(obj) ?? $"< {obj.GetType().Name} >";
+                return GetNamedObjectLabel(obj) ?? GetParameterObjectLabel(obj) ?? GetFamilyParameterObjectLabel(obj) ?? $"{obj.GetType().Name}";
         }
     }
 


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 
Improve show detail label of tree view name, when we remove character `< >`, we can search sub tree view by index from keyboard.
**Description:** 
Before : 
![Revit_uxvJk4e8Vj](https://user-images.githubusercontent.com/31106432/157583106-cdccb1f7-5a2b-4c23-8ca3-a748a594089c.png)
After : 
![Revit_jqpfRJ7wvV](https://user-images.githubusercontent.com/31106432/157583120-e2f5fe89-6aba-45a3-83d4-1b1c4b3961b9.png)
Demo with search index A->Z from keyboard
![Revit_w4ix6r7mic](https://user-images.githubusercontent.com/31106432/157583221-6f358d46-c857-4e09-8498-c56b76ee0e41.gif)


## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings