### PR TITLE
Optional Snoop Selection in Modify Tab

### DIFF
--- a/RevitLookup/Application.cs
+++ b/RevitLookup/Application.cs
@@ -50,6 +50,7 @@ public class Application : ExternalApplication
 
         CreateRibbonPanel();
         await Host.StartHost();
+        CreateModifyPanel();
     }
 
     public override async void OnShutdown()
@@ -120,33 +121,46 @@ public class Application : ExternalApplication
         eventMonitorButton.SetImage("/RevitLookup;component/Resources/Images/RibbonIcon16.png");
         eventMonitorButton.SetLargeImage("/RevitLookup;component/Resources/Images/RibbonIcon32.png");
 
-        ////Add modify tab button
-        //foreach (var ribbonTab in ComponentManager.Ribbon.Tabs)
-        //{
-        //    if (ribbonTab.Id != "Modify") continue;
-        //    var modifyPanel = new RibbonPanel
-        //    {
-        //        Source = new RibbonPanelSource
-        //        {
-        //            Title = "RevitLookup",
-        //            Items =
-        //            {
-        //                new RibbonButton
-        //                {
-        //                    ShowText = true,
-        //                    Text = "Snoop\nselection",
-        //                    Size = RibbonItemSize.Large,
-        //                    Orientation = Orientation.Vertical,
-        //                    CommandHandler = new RelayCommand(() => SnoopSelectionCommand.Execute(RevitApi.UiApplication)),
-        //                    Image = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon16.png", UriKind.RelativeOrAbsolute)),
-        //                    LargeImage = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon32.png", UriKind.RelativeOrAbsolute))
-        //                }
-        //            }
-        //        }
-        //    };
+    }
 
-        //    ribbonTab.Panels.Add(modifyPanel);
-        //    break;
-        //}
+    private static RibbonPanel modifyPanel;
+    private static void CreateModifyPanel()
+    {
+        //Add modify tab button
+        foreach (var ribbonTab in ComponentManager.Ribbon.Tabs)
+        {
+            if (ribbonTab.Id != "Modify") continue;
+            modifyPanel = new RibbonPanel
+            {
+                Source = new RibbonPanelSource
+                {
+                    Title = "RevitLookup",
+                    Items =
+                    {
+                        new RibbonButton
+                        {
+                            ShowText = true,
+                            Text = "Snoop\nselection",
+                            Size = RibbonItemSize.Large,
+                            Orientation = Orientation.Vertical,
+                            CommandHandler = new RelayCommand(() => SnoopSelectionCommand.Execute(RevitApi.UiApplication)),
+                            Image = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon16.png", UriKind.RelativeOrAbsolute)),
+                            LargeImage = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon32.png", UriKind.RelativeOrAbsolute))
+                        }
+                    }
+                }
+            };
+
+            ribbonTab.Panels.Add(modifyPanel);
+            break;
+        }
+
+        var settingsService = Host.GetService<ISettingsService>();
+        modifyPanel.IsVisible = settingsService.IsModifyPanelVisible;
+    }
+    public static void UpdateModifyPanelVisibility(bool visible)
+    {
+        if (modifyPanel == null) return;
+        modifyPanel.IsVisible = visible;
     }
 }

--- a/RevitLookup/Application.cs
+++ b/RevitLookup/Application.cs
@@ -92,6 +92,10 @@ public class Application : ExternalApplication
         splitDatabaseButton.SetImage("/RevitLookup;component/Resources/Images/RibbonIcon16.png");
         splitDatabaseButton.SetLargeImage("/RevitLookup;component/Resources/Images/RibbonIcon32.png");
 
+        var splitSelectionButton = splitButton.AddPushButton<SnoopSelectionCommand>("Snoop Selection");
+        splitSelectionButton.SetImage("/RevitLookup;component/Resources/Images/RibbonIcon16.png");
+        splitSelectionButton.SetLargeImage("/RevitLookup;component/Resources/Images/RibbonIcon32.png");
+
         var splitFaceButton = splitButton.AddPushButton<SnoopFaceCommand>("Snoop Face");
         splitFaceButton.SetImage("/RevitLookup;component/Resources/Images/RibbonIcon16.png");
         splitFaceButton.SetLargeImage("/RevitLookup;component/Resources/Images/RibbonIcon32.png");
@@ -116,33 +120,33 @@ public class Application : ExternalApplication
         eventMonitorButton.SetImage("/RevitLookup;component/Resources/Images/RibbonIcon16.png");
         eventMonitorButton.SetLargeImage("/RevitLookup;component/Resources/Images/RibbonIcon32.png");
 
-        //Add modify tab button
-        foreach (var ribbonTab in ComponentManager.Ribbon.Tabs)
-        {
-            if (ribbonTab.Id != "Modify") continue;
-            var modifyPanel = new RibbonPanel
-            {
-                Source = new RibbonPanelSource
-                {
-                    Title = "RevitLookup",
-                    Items =
-                    {
-                        new RibbonButton
-                        {
-                            ShowText = true,
-                            Text = "Snoop\nselection",
-                            Size = RibbonItemSize.Large,
-                            Orientation = Orientation.Vertical,
-                            CommandHandler = new RelayCommand(() => SnoopSelectionCommand.Execute(RevitApi.UiApplication)),
-                            Image = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon16.png", UriKind.RelativeOrAbsolute)),
-                            LargeImage = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon32.png", UriKind.RelativeOrAbsolute))
-                        }
-                    }
-                }
-            };
+        ////Add modify tab button
+        //foreach (var ribbonTab in ComponentManager.Ribbon.Tabs)
+        //{
+        //    if (ribbonTab.Id != "Modify") continue;
+        //    var modifyPanel = new RibbonPanel
+        //    {
+        //        Source = new RibbonPanelSource
+        //        {
+        //            Title = "RevitLookup",
+        //            Items =
+        //            {
+        //                new RibbonButton
+        //                {
+        //                    ShowText = true,
+        //                    Text = "Snoop\nselection",
+        //                    Size = RibbonItemSize.Large,
+        //                    Orientation = Orientation.Vertical,
+        //                    CommandHandler = new RelayCommand(() => SnoopSelectionCommand.Execute(RevitApi.UiApplication)),
+        //                    Image = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon16.png", UriKind.RelativeOrAbsolute)),
+        //                    LargeImage = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon32.png", UriKind.RelativeOrAbsolute))
+        //                }
+        //            }
+        //        }
+        //    };
 
-            ribbonTab.Panels.Add(modifyPanel);
-            break;
-        }
+        //    ribbonTab.Panels.Add(modifyPanel);
+        //    break;
+        //}
     }
 }

--- a/RevitLookup/Application.cs
+++ b/RevitLookup/Application.cs
@@ -78,6 +78,7 @@ public class Application : ExternalApplication
         var splitButton = ribbonPanel.AddSplitButton("RevitLookup", "Interaction");
 
         var splitDashboardButton = splitButton.AddPushButton<DashboardCommand>("Dashboard");
+        splitDashboardButton.SetAvailabilityController<AlwaysCommandAvailability>();
         splitDashboardButton.SetImage("/RevitLookup;component/Resources/Images/RibbonIcon16.png");
         splitDashboardButton.SetLargeImage("/RevitLookup;component/Resources/Images/RibbonIcon32.png");
 

--- a/RevitLookup/Application.cs
+++ b/RevitLookup/Application.cs
@@ -127,16 +127,12 @@ public class Application : ExternalApplication
     private static RibbonPanel modifyPanel;
     private static void CreateModifyPanel()
     {
-        //Add modify tab button
-        foreach (var ribbonTab in ComponentManager.Ribbon.Tabs)
+        modifyPanel = new RibbonPanel
         {
-            if (ribbonTab.Id != "Modify") continue;
-            modifyPanel = new RibbonPanel
+            Source = new RibbonPanelSource
             {
-                Source = new RibbonPanelSource
-                {
-                    Title = "RevitLookup",
-                    Items =
+                Title = "RevitLookup",
+                Items =
                     {
                         new RibbonButton
                         {
@@ -149,19 +145,28 @@ public class Application : ExternalApplication
                             LargeImage = new BitmapImage(new Uri(@"/RevitLookup;component/Resources/Images/RibbonIcon32.png", UriKind.RelativeOrAbsolute))
                         }
                     }
-                }
-            };
-
-            ribbonTab.Panels.Add(modifyPanel);
-            break;
-        }
+            }
+        };
 
         var settingsService = Host.GetService<ISettingsService>();
-        modifyPanel.IsVisible = settingsService.IsModifyPanelVisible;
+        UpdateModifyPanelVisibility(settingsService.IsModifyPanelVisible);
     }
     public static void UpdateModifyPanelVisibility(bool visible)
     {
         if (modifyPanel == null) return;
-        modifyPanel.IsVisible = visible;
+
+        //Add/Remove modify tab button
+        foreach (var ribbonTab in ComponentManager.Ribbon.Tabs)
+        {
+            if (ribbonTab.Id != "Modify") continue;
+            var contains = ribbonTab.Panels.Contains(modifyPanel);
+
+            if (visible && !contains)
+                ribbonTab.Panels.Add(modifyPanel);
+            else if (!visible && contains)
+                ribbonTab.Panels.Remove(modifyPanel);
+
+            break;
+        }
     }
 }

--- a/RevitLookup/Commands/AlwaysCommandAvailability.cs
+++ b/RevitLookup/Commands/AlwaysCommandAvailability.cs
@@ -1,4 +1,4 @@
-// Copyright 2003-2023 by Autodesk, Inc.
+﻿// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -18,23 +18,15 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
-using Autodesk.Revit.Attributes;
-using Microsoft.Extensions.DependencyInjection;
-using Nice3point.Revit.Toolkit.External;
-using RevitLookup.Services.Contracts;
-using RevitLookup.Views.Pages;
-using Wpf.Ui.Contracts;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
 
 namespace RevitLookup.Commands;
 
-[UsedImplicitly]
-[Transaction(TransactionMode.Manual)]
-public class DashboardCommand : ExternalCommand
+public class AlwaysCommandAvailability : IExternalCommandAvailability
 {
-    public override void Execute()
+    public bool IsCommandAvailable(UIApplication applicationData, CategorySet selectedCategories)
     {
-        var window = Host.GetService<IWindow>();
-        window.Show(UiApplication.MainWindowHandle);
-        window.Scope.GetService<INavigationService>().Navigate(typeof(DashboardView));
+        return true;
     }
 }

--- a/RevitLookup/Services/Contracts/ISettingsService.cs
+++ b/RevitLookup/Services/Contracts/ISettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -30,6 +30,7 @@ public interface ISettingsService
     int TransitionDuration { get; }
     bool IsExtensionsAllowed { get; set; }
     bool IsUnsupportedAllowed { get; set; }
+    bool IsModifyPanelVisible { get; set; }
     int ApplyTransition(bool value);
     void Save();
 }

--- a/RevitLookup/Services/SettingsService.cs
+++ b/RevitLookup/Services/SettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -70,6 +70,12 @@ public sealed class SettingsService : ISettingsService
         set => _settings.IsUnsupportedAllowed = value;
     }
 
+    public bool IsModifyPanelVisible
+    {
+        get => _settings.IsModifyVisible;
+        set => _settings.IsModifyVisible = value;
+    }
+
     public int ApplyTransition(bool value)
     {
         return TransitionDuration = value ? DefaultTransitionDuration : 0;
@@ -124,4 +130,5 @@ internal sealed class Settings
     public int TransitionDuration { get; set; } // = SettingsService.DefaultTransitionDuration;
     public bool IsExtensionsAllowed { get; set; }
     public bool IsUnsupportedAllowed { get; set; }
+    public bool IsModifyVisible { get; set; }
 }

--- a/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
+++ b/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
@@ -93,4 +93,10 @@ public sealed partial class SettingsViewModel : ObservableObject
     {
         _settingsService.IsExtensionsAllowed = value;
     }
+
+    partial void OnIsModifyPanelVisibleChanged(bool value)
+    {
+        Application.UpdateModifyPanelVisibility(value);
+        _settingsService.IsModifyPanelVisible = value;
+    }
 }

--- a/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
+++ b/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -37,6 +37,7 @@ public sealed partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool _isExtensionsAllowed;
     [ObservableProperty] private bool _isSmoothEnabled;
     [ObservableProperty] private bool _isUnsupportedAllowed;
+    [ObservableProperty] private bool _isModifyPanelVisible;
     [ObservableProperty] private ThemeType _theme;
 
     public SettingsViewModel(ISettingsService settingsService, INavigationService navigationService, ISnackbarService snackbarService)
@@ -49,6 +50,7 @@ public sealed partial class SettingsViewModel : ObservableObject
         _isSmoothEnabled = settingsService.TransitionDuration > 0;
         _isUnsupportedAllowed = settingsService.IsUnsupportedAllowed;
         _isExtensionsAllowed = settingsService.IsExtensionsAllowed;
+        _isModifyPanelVisible = settingsService.IsModifyPanelVisible;
     }
 
     public List<ThemeType> Themes { get; } = new()

--- a/RevitLookup/Views/Pages/SettingsView.xaml
+++ b/RevitLookup/Views/Pages/SettingsView.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="RevitLookup.Views.Pages.SettingsView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -56,6 +56,11 @@
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
+            </rl:CardControl>
+            <rl:CardControl Header="Modify Panel Visible"
+                            Icon="VideoClipMultiple24"
+                            Margin="0,8,0,0">
+                <rl:ToggleSwitch IsChecked="{Binding ViewModel.IsModifyPanelVisible}" />
             </rl:CardControl>
             <rl:CardControl
                 Header="Smooth navigation"

--- a/RevitLookup/Views/Pages/SettingsView.xaml
+++ b/RevitLookup/Views/Pages/SettingsView.xaml
@@ -58,7 +58,7 @@
                 </ComboBox>
             </rl:CardControl>
             <rl:CardControl Header="Modify Panel Visible"
-                            Icon="VideoClipMultiple24"
+                            Icon="WindowApps24"
                             Margin="0,8,0,0">
                 <rl:ToggleSwitch IsChecked="{Binding ViewModel.IsModifyPanelVisible}" />
             </rl:CardControl>


### PR DESCRIPTION
# Summary of the Pull Request
Feature to enable/disable the Snoop Selection in Modify Tab in the setting.

**What is this about:** 
* Add enable/disable the Snoop Selection in Modify Tab in the setting.
* Add Snoop Selection Command in the RevitLookup (#150)
* Add Always Command Availability in the Dashboard command

**Description:** 
I tried to follow your pattern to create the new setting, everything looks great except `Application.UpdateModifyPanelVisibility` is hardcoded in the SettingViewModel, I didn't know if I should create an interface in the ISettingsService and move the `Application.UpdateModifyPanelVisibility` to the SettingsService.

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings