### PR TITLE
Separate thread for UI

### DIFF
--- a/RevitLookup/Application.cs
+++ b/RevitLookup/Application.cs
@@ -82,22 +82,25 @@ public class Application : ExternalApplication
         if (!settingsService.IsHardwareRenderingAllowed) return;
         if (_thread is not null) return;
 
-        RenderOptions.ProcessRenderMode = RenderMode.Default;
-
         _thread = new Thread(Dispatcher.Run);
         _thread.SetApartmentState(ApartmentState.STA);
         _thread.Start();
+
+        //Revit overrides render mode during initialization
+        //EventHandler is called after initialisation
+        ActionEventHandler.Raise(_ => RenderOptions.ProcessRenderMode = RenderMode.Default);
     }
 
     public static void TerminateDispatcher(ISettingsService settingsService)
     {
         if (settingsService.IsHardwareRenderingAllowed) return;
+        if (_thread is null) return;
         if (!_thread.IsAlive) return;
-
-        RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
 
         Dispatcher.FromThread(_thread)!.InvokeShutdown();
         _thread = null;
+
+        RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
     }
 
     public static void Invoke(Action action)

--- a/RevitLookup/Application.cs
+++ b/RevitLookup/Application.cs
@@ -22,7 +22,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Windows.Interop;
 using System.Windows.Media;
-using Autodesk.Revit.DB.Events;
+using System.Windows.Threading;
 using Nice3point.Revit.Toolkit.External;
 using Nice3point.Revit.Toolkit.External.Handlers;
 using RevitLookup.Core;
@@ -34,6 +34,7 @@ namespace RevitLookup;
 [UsedImplicitly]
 public class Application : ExternalApplication
 {
+    private static Thread _thread;
     public static ActionEventHandler ActionEventHandler { get; private set; }
     public static AsyncEventHandler<IReadOnlyCollection<SnoopableObject>> ExternalElementHandler { get; private set; }
     public static AsyncEventHandler<IReadOnlyCollection<Descriptor>> ExternalDescriptorHandler { get; private set; }
@@ -47,7 +48,7 @@ public class Application : ExternalApplication
 
         var settingsService = Host.GetService<ISettingsService>();
         RibbonController.CreatePanel(Application, settingsService);
-        EnableHardwareRendering(settingsService);
+        RunDispatcher(settingsService);
     }
 
     public override async void OnShutdown()
@@ -76,17 +77,32 @@ public class Application : ExternalApplication
         settingsService.Save();
     }
 
-    private void EnableHardwareRendering(ISettingsService settingsService)
+    public static void RunDispatcher(ISettingsService settingsService)
     {
         if (!settingsService.IsHardwareRenderingAllowed) return;
+        if (_thread is not null) return;
 
-        //Revit overrides render mode during initialization
-        Application.ControlledApplication.ApplicationInitialized += OnInitialized;
+        RenderOptions.ProcessRenderMode = RenderMode.Default;
 
-        void OnInitialized(object sender, ApplicationInitializedEventArgs args)
-        {
-            Application.ControlledApplication.ApplicationInitialized -= OnInitialized;
-            RenderOptions.ProcessRenderMode = RenderMode.Default;
-        }
+        _thread = new Thread(Dispatcher.Run);
+        _thread.SetApartmentState(ApartmentState.STA);
+        _thread.Start();
+    }
+
+    public static void TerminateDispatcher(ISettingsService settingsService)
+    {
+        if (settingsService.IsHardwareRenderingAllowed) return;
+        if (!_thread.IsAlive) return;
+
+        RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
+
+        Dispatcher.FromThread(_thread)!.InvokeShutdown();
+        _thread = null;
+    }
+
+    public static void Invoke(Action action)
+    {
+        if (_thread is null) action.Invoke();
+        else Dispatcher.FromThread(_thread)!.Invoke(action);
     }
 }

--- a/RevitLookup/Commands/DashboardCommand.cs
+++ b/RevitLookup/Commands/DashboardCommand.cs
@@ -18,7 +18,6 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
-using System.Windows.Media;
 using Autodesk.Revit.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Nice3point.Revit.Toolkit.External;

--- a/RevitLookup/Commands/DashboardCommand.cs
+++ b/RevitLookup/Commands/DashboardCommand.cs
@@ -18,6 +18,7 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
+using System.Windows.Media;
 using Autodesk.Revit.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using Nice3point.Revit.Toolkit.External;
@@ -33,8 +34,13 @@ public class DashboardCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.ShowAttached();
-        window.Scope.GetService<INavigationService>().Navigate(typeof(DashboardView));
+        var processRenderMode = RenderOptions.ProcessRenderMode;
+        RevitLookup.Application.Invoke(() =>
+        {
+            var processRenderMode2 = RenderOptions.ProcessRenderMode;
+            var window = Host.GetService<IWindow>();
+            window.ShowAttached();
+            window.Scope.GetService<INavigationService>().Navigate(typeof(DashboardView));
+        });
     }
 }

--- a/RevitLookup/Commands/DashboardCommand.cs
+++ b/RevitLookup/Commands/DashboardCommand.cs
@@ -34,10 +34,8 @@ public class DashboardCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var processRenderMode = RenderOptions.ProcessRenderMode;
         RevitLookup.Application.Invoke(() =>
         {
-            var processRenderMode2 = RenderOptions.ProcessRenderMode;
             var window = Host.GetService<IWindow>();
             window.ShowAttached();
             window.Scope.GetService<INavigationService>().Navigate(typeof(DashboardView));

--- a/RevitLookup/Commands/EventMonitorCommand.cs
+++ b/RevitLookup/Commands/EventMonitorCommand.cs
@@ -33,8 +33,11 @@ public class EventMonitorCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.ShowAttached();
-        window.Scope.GetService<INavigationService>().Navigate(typeof(EventsView));
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.ShowAttached();
+            window.Scope.GetService<INavigationService>().Navigate(typeof(EventsView));
+        });
     }
 }

--- a/RevitLookup/Commands/SearchElementsCommand.cs
+++ b/RevitLookup/Commands/SearchElementsCommand.cs
@@ -34,9 +34,12 @@ public class SearchElementsCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.ShowAttached();
-        window.Scope.GetService<INavigationService>().Navigate(typeof(DashboardView));
-        window.Scope.GetService<DashboardViewModel>().OpenDialogCommand.Execute("search");
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.ShowAttached();
+            window.Scope.GetService<INavigationService>().Navigate(typeof(DashboardView));
+            window.Scope.GetService<DashboardViewModel>().OpenDialogCommand.Execute("search");
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopDatabaseCommand.cs
+++ b/RevitLookup/Commands/SnoopDatabaseCommand.cs
@@ -32,8 +32,11 @@ public class SnoopDatabaseCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Database);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Database);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopDocumentCommand.cs
+++ b/RevitLookup/Commands/SnoopDocumentCommand.cs
@@ -32,8 +32,11 @@ public class SnoopDocumentCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Document);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Document);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopEdgeCommand.cs
+++ b/RevitLookup/Commands/SnoopEdgeCommand.cs
@@ -32,8 +32,11 @@ public class SnoopEdgeCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Edge);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Edge);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopFaceCommand.cs
+++ b/RevitLookup/Commands/SnoopFaceCommand.cs
@@ -32,8 +32,11 @@ public class SnoopFaceCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Face);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Face);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopLinkedElementCommand.cs
+++ b/RevitLookup/Commands/SnoopLinkedElementCommand.cs
@@ -32,8 +32,11 @@ public class SnoopLinkedElementCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.LinkedElement);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.LinkedElement);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopPointCommand.cs
+++ b/RevitLookup/Commands/SnoopPointCommand.cs
@@ -32,8 +32,11 @@ public class SnoopPointCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Point);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Point);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopSelectionCommand.cs
+++ b/RevitLookup/Commands/SnoopSelectionCommand.cs
@@ -32,8 +32,11 @@ public class SnoopSelectionCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Selection);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.Selection);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopSubElementCommand.cs
+++ b/RevitLookup/Commands/SnoopSubElementCommand.cs
@@ -32,8 +32,11 @@ public class SnoopSubElementCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.SubElement);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.SubElement);
+        });
     }
 }

--- a/RevitLookup/Commands/SnoopViewCommand.cs
+++ b/RevitLookup/Commands/SnoopViewCommand.cs
@@ -32,8 +32,11 @@ public class SnoopViewCommand : ExternalCommand
 {
     public override void Execute()
     {
-        var window = Host.GetService<IWindow>();
-        window.Initialize();
-        window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.View);
+        RevitLookup.Application.Invoke(() =>
+        {
+            var window = Host.GetService<IWindow>();
+            window.Initialize();
+            window.Scope.GetService<ISnoopService>()!.Snoop(SnoopableType.View);
+        });
     }
 }

--- a/RevitLookup/Services/SettingsService.cs
+++ b/RevitLookup/Services/SettingsService.cs
@@ -36,7 +36,7 @@ internal sealed class Settings
 {
     public ThemeType Theme { get; set; } = ThemeType.Light;
     public WindowBackdropType Background { get; set; } = WindowBackdropType.None;
-    public int TransitionDuration { get; set; } // = SettingsService.DefaultTransitionDuration;
+    public int TransitionDuration { get; set; } = SettingsService.DefaultTransitionDuration;
     public bool IsExtensionsAllowed { get; set; }
     public bool IsUnsupportedAllowed { get; set; }
     public bool IsModifyTabAllowed { get; set; }
@@ -45,7 +45,7 @@ internal sealed class Settings
 
 public sealed class SettingsService : ISettingsService
 {
-    private const int DefaultTransitionDuration = 200;
+    public const int DefaultTransitionDuration = 200;
     private readonly Settings _settings;
     private readonly string _settingsFile;
 

--- a/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
+++ b/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
@@ -18,8 +18,6 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
-using System.Windows.Interop;
-using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using RevitLookup.Services.Contracts;
 using Wpf.Ui.Appearance;
@@ -106,7 +104,8 @@ public sealed partial class SettingsViewModel : ObservableObject
 
     partial void OnIsHardwareRenderingAllowedChanged(bool value)
     {
-        _settingsService.IsModifyTabAllowed = value;
-        RenderOptions.ProcessRenderMode = value ? RenderMode.Default : RenderMode.SoftwareOnly;
+        _settingsService.IsHardwareRenderingAllowed = value;
+        if (value) Application.RunDispatcher(_settingsService);
+        else Application.TerminateDispatcher(_settingsService);
     }
 }


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 

Support for a new thread for the user interface

**Description:** 

The feature is added to the existing "Hardware acceleration" option. 
The new thread allows us to offload the main thread and reduce interface freezes while Revit performs its tasks.

Need more tests to add this feature and possibly change the code. Turning it off closes all instances of RevitLookup, which may come as a surprise

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings