### PR TITLE
Show family parameter names

### DIFF
--- a/RevitLookup/Core/ComponentModel/DescriptorMap.cs
+++ b/RevitLookup/Core/ComponentModel/DescriptorMap.cs
@@ -65,6 +65,7 @@ public static class DescriptorMap
             //APIObjects
             Category value when type is null || type == typeof(Category) => new CategoryDescriptor(value),
             Parameter value when type is null || type == typeof(Parameter) => new ParameterDescriptor(value),
+            FamilyParameter value when type is null || type == typeof(FamilyParameter) => new FamilyParameterDescriptor(value),
             Reference value when type is null || type == typeof(Reference) => new ReferenceDescriptor(value),
             Color value when type is null || type == typeof(Color) => new ColorDescriptor(value),
             Curve value when type is null || type == typeof(Curve) => new CurveDescriptor(value),

--- a/RevitLookup/Core/ComponentModel/Descriptors/FamilyParameterDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/FamilyParameterDescriptor.cs
@@ -1,0 +1,32 @@
+// Copyright 2003-2023 by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using Autodesk.Revit.DB;
+using RevitLookup.Core.Objects;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public sealed class FamilyParameterDescriptor : Descriptor
+{
+    public FamilyParameterDescriptor(FamilyParameter familyParameter)
+    {
+        Name = familyParameter.Definition.Name;
+    }
+}


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 
Shows family parameters names for user instead of "FamilyParameter"

**Description:** 
![family manager parameters](https://github.com/jeremytammik/RevitLookup/assets/14212214/d049462c-296a-4c70-872c-94141d5bc92b)
## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings