### PR TITLE
An extension to show associated family parameters

### DIFF
--- a/RevitLookup/Core/ComponentModel/Descriptors/FamilyParameterDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/FamilyParameterDescriptor.cs
@@ -18,15 +18,24 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
+using System.Reflection;
 using Autodesk.Revit.DB;
+using RevitLookup.Core.Contracts;
 using RevitLookup.Core.Objects;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
 
-public sealed class FamilyParameterDescriptor : Descriptor
+public sealed class FamilyParameterDescriptor : Descriptor, IDescriptorResolver
 {
     public FamilyParameterDescriptor(FamilyParameter familyParameter)
     {
         Name = familyParameter.Definition.Name;
+    }
+
+    public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
+    {
+        // TODO: Nice3point, without this magic the parameter extension which gets an associated family parameter shows non-snoopable text
+
+        return null;
     }
 }

--- a/RevitLookup/Core/ComponentModel/Descriptors/FamilyParameterDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/FamilyParameterDescriptor.cs
@@ -18,24 +18,16 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
-using System.Reflection;
 using Autodesk.Revit.DB;
 using RevitLookup.Core.Contracts;
 using RevitLookup.Core.Objects;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
 
-public sealed class FamilyParameterDescriptor : Descriptor, IDescriptorResolver
+public sealed class FamilyParameterDescriptor : Descriptor, IDescriptorCollector
 {
     public FamilyParameterDescriptor(FamilyParameter familyParameter)
     {
         Name = familyParameter.Definition.Name;
-    }
-
-    public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
-    {
-        // TODO: Nice3point, without this magic the parameter extension which gets an associated family parameter shows non-snoopable text
-
-        return null;
     }
 }

--- a/RevitLookup/Core/ComponentModel/Descriptors/ParameterDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/ParameterDescriptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -21,6 +21,7 @@
 using System.Reflection;
 using Autodesk.Revit.DB;
 using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Extensions;
 using RevitLookup.Core.Objects;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
@@ -48,6 +49,12 @@ public sealed class ParameterDescriptor : Descriptor, IDescriptorResolver, IDesc
             extension.Name = nameof(ParameterExtensions.AsColor);
             extension.Result = extension.Value.AsColor();
         });
+
+        manager.Register(_parameter, extension =>
+        {
+            extension.Name = nameof(FamilyManager.GetAssociatedFamilyParameter);
+            extension.Result = GetAssociatedFamilyParameter(extension);
+        });
     }
 
     public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
@@ -58,4 +65,9 @@ public sealed class ParameterDescriptor : Descriptor, IDescriptorResolver, IDesc
             _ => null
         };
     }
+
+    private static FamilyParameter GetAssociatedFamilyParameter(DescriptorExtension<Parameter> extension)
+        => extension.Context is { IsFamilyDocument: true }
+            ? extension.Context.FamilyManager.GetAssociatedFamilyParameter(extension.Value)
+            : null;
 }

--- a/RevitLookup/Core/ComponentModel/Descriptors/ParameterDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/ParameterDescriptor.cs
@@ -50,11 +50,12 @@ public sealed class ParameterDescriptor : Descriptor, IDescriptorResolver, IDesc
             extension.Result = extension.Value.AsColor();
         });
 
-        manager.Register(_parameter, extension =>
-        {
-            extension.Name = nameof(FamilyManager.GetAssociatedFamilyParameter);
-            extension.Result = GetAssociatedFamilyParameter(extension);
-        });
+        if (manager.Context is { IsFamilyDocument: true })
+            manager.Register(_parameter, extension =>
+            {
+                extension.Name = nameof(FamilyManager.GetAssociatedFamilyParameter);
+                extension.Result = GetAssociatedFamilyParameter(extension);
+            });
     }
 
     public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)

--- a/RevitLookup/Core/ComponentModel/Descriptors/ParameterDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/ParameterDescriptor.cs
@@ -21,7 +21,6 @@
 using System.Reflection;
 using Autodesk.Revit.DB;
 using RevitLookup.Core.Contracts;
-using RevitLookup.Core.Extensions;
 using RevitLookup.Core.Objects;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
@@ -54,7 +53,7 @@ public sealed class ParameterDescriptor : Descriptor, IDescriptorResolver, IDesc
             manager.Register(_parameter, extension =>
             {
                 extension.Name = nameof(FamilyManager.GetAssociatedFamilyParameter);
-                extension.Result = GetAssociatedFamilyParameter(extension);
+                extension.Result = extension.Context.FamilyManager.GetAssociatedFamilyParameter(extension.Value);
             });
     }
 
@@ -66,9 +65,4 @@ public sealed class ParameterDescriptor : Descriptor, IDescriptorResolver, IDesc
             _ => null
         };
     }
-
-    private static FamilyParameter GetAssociatedFamilyParameter(DescriptorExtension<Parameter> extension)
-        => extension.Context is { IsFamilyDocument: true }
-            ? extension.Context.FamilyManager.GetAssociatedFamilyParameter(extension.Value)
-            : null;
 }

--- a/RevitLookup/Core/Contracts/IExtensionManager.cs
+++ b/RevitLookup/Core/Contracts/IExtensionManager.cs
@@ -18,11 +18,14 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
+using Autodesk.Revit.DB;
 using RevitLookup.Core.Extensions;
 
 namespace RevitLookup.Core.Contracts;
 
 public interface IExtensionManager
 {
+    Document Context { get; }
+
     void Register<T>(T value, Action<DescriptorExtension<T>> extension);
 }

--- a/RevitLookup/Core/Extensions/ExtensionManager.cs
+++ b/RevitLookup/Core/Extensions/ExtensionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -25,12 +25,12 @@ namespace RevitLookup.Core.Extensions;
 
 public sealed class ExtensionManager : IExtensionManager
 {
-    private readonly Document _context;
-
     public ExtensionManager(Document context)
     {
-        _context = context;
+        Context = context;
     }
+
+    public Document Context { get; }
 
     public Dictionary<string, object> ValuesMap { get; } = new();
 
@@ -39,7 +39,7 @@ public sealed class ExtensionManager : IExtensionManager
         var descriptorExtension = new DescriptorExtension<T>
         {
             Value = value,
-            Context = _context
+            Context = Context
         };
 
         try


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 
Added an ability to show associated family parameters
**Description:** 
![lookup](https://github.com/jeremytammik/RevitLookup/assets/14212214/799047cf-0de3-4a5e-a9b8-31e823d0c31a)


## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# Issues (the PR is a draft now)
1. it requires the magic to make the family parameter snoopable:
```cs
public sealed class FamilyParameterDescriptor : Descriptor, IDescriptorResolver // <-- !!!
{
    ...
    public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
    {
        return null; // <-- !!!
    }
}
```
otherwise it shows a non-snoopable text like:
![non-snoopable](https://github.com/jeremytammik/RevitLookup/assets/14212214/a9577924-0ed6-48f7-9bf4-b7905d7bfd40)

if I remove FamilyParameterDescriptor registration (what I obviously don't want to do :-)) https://github.com/jeremytammik/RevitLookup/blob/f52d2fef57c27159d0029866daba12bf482c5351/RevitLookup/Core/ComponentModel/DescriptorMap.cs#L68, it also becomes snoopable:
![snoopable-if-remove-the descriptor](https://github.com/jeremytammik/RevitLookup/assets/14212214/c8c66615-0dd2-4f63-ab01-d4fb78683fa7)

@Nice3point , you know the codebase much deeper than me, probably, it's better if you'll fix it :-)

2. As a suggestion would be nice to extend IExtensionManager or DescriptorExtension to be able to control when the extension should be added, for example adding another extension registration method like:

```cs
void Register<T>(T value, Action<DescriptorExtension<T>> extension, Func<DescriptorExtension<T>, bool> isActive);
```
So we'll avoid adding GetAssociateFamilyParameters extension in non-family editor contexts
