### PR TITLE
An expicit Resharper rules for private fields

### DIFF
--- a/RevitLookup.sln.DotSettings
+++ b/RevitLookup.sln.DotSettings
@@ -18,6 +18,8 @@ Use, duplication, or disclosure by the U.S. Government is subject to
 restrictions set forth in FAR 52.227-19 (Commercial Computer
 Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 (Rights in Technical Data and Computer Software), as applicable.</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addin/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Addins/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=APIUI/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
for those like me who hates any prefixes of vars, fields, props etc. and who wants to calm down R# / Rider on RevitLookup project.

Nothing is changed for others.