### PR TITLE
GetBoundarySegments method of spatial elements support added

### DIFF
--- a/RevitLookup/Core/ComponentModel/DescriptorMap.cs
+++ b/RevitLookup/Core/ComponentModel/DescriptorMap.cs
@@ -99,6 +99,8 @@ public static class DescriptorMap
             CompoundStructureLayer value when type is null || type == typeof(CompoundStructureLayer) => new CompoundStructureLayerDescriptor(value),
             Workset value when type is null || type == typeof(Workset) => new WorksetDescriptor(value),
             WorksetTable when type is null || type == typeof(WorksetTable) => new WorksetTableDescriptor(),
+            BoundarySegment value when type is null || type == typeof(BoundarySegment) => new BoundarySegmentDescriptor(value),
+            SpatialElement value when type is null || type == typeof(SpatialElement) => new SpatialElementDescriptor(value),
 #if R24_OR_GREATER
             EvaluatedParameter value when type is null || type == typeof(EvaluatedParameter) => new EvaluatedParameterDescriptor(value),
 #endif

--- a/RevitLookup/Core/ComponentModel/Descriptors/BoundarySegmentDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/BoundarySegmentDescriptor.cs
@@ -1,0 +1,33 @@
+// Copyright 2003-$File.CreatedYear by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using Autodesk.Revit.DB;
+using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public class BoundarySegmentDescriptor : Descriptor, IDescriptorCollector
+{
+    public BoundarySegmentDescriptor(BoundarySegment boundarySegment)
+    {
+        Name = $"ID: {boundarySegment.ElementId}, {boundarySegment.GetCurve()?.Length} ft";
+    }
+}

--- a/RevitLookup/Core/ComponentModel/Descriptors/SpatialElementDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/SpatialElementDescriptor.cs
@@ -1,0 +1,84 @@
+// Copyright 2003-$File.CreatedYear by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using System.Reflection;
+using Autodesk.Revit.DB;
+using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public class SpatialElementDescriptor : ElementDescriptor, IDescriptorResolver
+{
+    private readonly SpatialElement _spatialElement;
+    public SpatialElementDescriptor(SpatialElement spatialElement) : base(spatialElement)
+    {
+        _spatialElement = spatialElement;
+    }
+
+    public new ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
+    {
+        return target switch
+        {
+            nameof(SpatialElement.GetBoundarySegments) => new ResolveSet(8)
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.Center,
+                    StoreFreeBoundaryFaces = true
+                }), $"Center, store free boundary faces")
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.CoreBoundary,
+                    StoreFreeBoundaryFaces = true
+                }), "Core boundary, store free boundary faces")
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.Finish,
+                    StoreFreeBoundaryFaces = true
+                }), "Finish, store free boundary faces")
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.CoreCenter,
+                    StoreFreeBoundaryFaces = true
+                }), "Core center, store free boundary faces")
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.Center,
+                    StoreFreeBoundaryFaces = true
+                }), "Center")
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.CoreBoundary,
+                    StoreFreeBoundaryFaces = true
+                }), "Core boundary")
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.Finish,
+                    StoreFreeBoundaryFaces = true
+                }), "Finish")
+                .AppendVariant(_spatialElement.GetBoundarySegments(new SpatialElementBoundaryOptions()
+                {
+                    SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.CoreCenter,
+                    StoreFreeBoundaryFaces = true
+                }), "Core center"),
+            _ => null
+        };
+    }
+}


### PR DESCRIPTION
# Summary of the Pull Request

**Adding support of displaying GetBoundarySegments method of SpatialElement class:** 

**User can now see all the boundary segments depends on SpatialElementBoundaryOptions in 8 variants. For boundary segments users can now see its IDs and length in Name in Left Panel to quickly analyze room boundaries. 
Added 2 classes: SpatialElementDescriptor and BoundarySegmentsDescriptor
** 

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings