### PR TITLE
Mep section methods support added

### DIFF
--- a/RevitLookup/Core/ComponentModel/DescriptorMap.cs
+++ b/RevitLookup/Core/ComponentModel/DescriptorMap.cs
@@ -25,6 +25,7 @@ using System.Windows.Threading;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.DB.ExtensibleStorage;
 using Autodesk.Revit.DB.ExternalService;
+using Autodesk.Revit.DB.Mechanical;
 using Autodesk.Windows;
 using RevitLookup.Core.ComponentModel.Descriptors;
 using RevitLookup.Core.Objects;
@@ -77,6 +78,7 @@ public static class DescriptorMap
             PrintManager value when type is null || type == typeof(PrintManager) => new PrintManagerDescriptor(value),
             DefinitionGroup value when type is null || type == typeof(DefinitionGroup) => new DefinitionGroupDescriptor(value),
             FamilyManager value when type is null || type == typeof(FamilyManager) => new FamilyManagerDescriptor(value),
+            MEPSection value when type is null || type == typeof(MEPSection) => new MepSectionDescriptor(value),
             APIObject when type is null || type == typeof(APIObject) => new ApiObjectDescriptor(),
 
             //IDisposables

--- a/RevitLookup/Core/ComponentModel/Descriptors/MepSectionDescriptor.cs
+++ b/RevitLookup/Core/ComponentModel/Descriptors/MepSectionDescriptor.cs
@@ -1,0 +1,102 @@
+// Copyright 2003-$File.CreatedYear by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using System.Reflection;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Mechanical;
+using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+using ArgumentException = Autodesk.Revit.Exceptions.ArgumentException;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public class MepSectionDescriptor : Descriptor, IDescriptorResolver
+{
+    private MEPSection _mepSection;
+    public MepSectionDescriptor(MEPSection mepSection)
+    {
+        _mepSection = mepSection;
+    }
+    public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
+    {
+        return target switch
+        {
+            nameof(MEPSection.GetElementIds) => ResolveSectionIds(),
+            nameof(MEPSection.GetCoefficient) => ResolveCoefficient(),
+            nameof(MEPSection.GetPressureDrop) => ResolvePressureDrop(),
+            nameof(MEPSection.GetSegmentLength) => ResolveSegmentLength(),
+            _ => null
+        };
+        
+        ResolveSet ResolveSectionIds()
+        {
+            var elementIds = _mepSection.GetElementIds();
+            var resolveSummary = new ResolveSet(elementIds.Count);
+            foreach (var id in elementIds)
+            {
+                resolveSummary.AppendVariant(id);
+            }
+            return resolveSummary;
+        }
+        ResolveSet ResolveCoefficient()
+        {
+            var elementIds = _mepSection.GetElementIds();
+            var resolveSummary = new ResolveSet(elementIds.Count);
+            foreach (var id in elementIds)
+            {
+                resolveSummary.AppendVariant(_mepSection.GetCoefficient(id), $"{id}");
+            }
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolvePressureDrop()
+        {
+            var elementIds = _mepSection.GetElementIds();
+            var resolveSummary = new ResolveSet(elementIds.Count);
+            foreach (var id in elementIds)
+            {
+                resolveSummary.AppendVariant(_mepSection.GetPressureDrop(id), $"{id}");
+            }
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveSegmentLength()
+        {
+            var elementIds = _mepSection.GetElementIds();
+            var resolveSummary = new ResolveSet(elementIds.Count);
+            foreach (var id in elementIds)
+            {
+                var length = 0.0d;
+                try
+                {
+                    length = _mepSection.GetSegmentLength(id);
+                }
+                catch (ArgumentException)
+                {
+                    // ignored
+                }
+                if (length != 0.0d) resolveSummary.AppendVariant(length, $"{id}");
+            }
+            return resolveSummary;
+        }
+    }
+
+    
+}


### PR DESCRIPTION
# Summary of the Pull Request

**Adding support of 4 methods of MEPSection class** 

**Now user can analyze MepSection and its elements in Revit Lookup. My commit has 3 methods with clean code. but I have a problem with GetSegmentLength method. It throws exceptions if we invoke it with argument which is not pipe or duct. But we have only ElementId, so I didn't find any way to recognize it and decided to use try-catch block. ** 

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings