### PR TITLE
Ignore `ActionEventHandler` when null - UI.Demo

### DIFF
--- a/source/RevitLookup.UI.Demo/HostProvider.cs
+++ b/source/RevitLookup.UI.Demo/HostProvider.cs
@@ -49,7 +49,7 @@ public static class HostProvider
         services.AddScoped<SettingsView>();
         services.AddScoped<SettingsViewModel>();
         services.AddScoped<EventsView>();
-        services.AddScoped<EventsViewModel>();
+        services.AddScoped<IEventsViewModel, EventsViewModel>();
         services.AddScoped<SnoopView>();
         services.AddScoped<ISnoopViewModel, MoqSnoopViewModel>();
         services.AddScoped<IWindow, RevitLookupView>();

--- a/source/RevitLookup.UI.Demo/HostProvider.cs
+++ b/source/RevitLookup.UI.Demo/HostProvider.cs
@@ -15,6 +15,7 @@ using RevitLookup.Views;
 using RevitLookup.Views.Pages;
 using Wpf.Ui;
 using MoqSnoopViewModel = RevitLookup.UI.Demo.Mock.MoqSnoopViewModel;
+using MoqEventsViewModel = RevitLookup.UI.Demo.Mock.MoqEventsViewModel;
 
 namespace RevitLookup.UI.Demo;
 
@@ -49,7 +50,7 @@ public static class HostProvider
         services.AddScoped<SettingsView>();
         services.AddScoped<SettingsViewModel>();
         services.AddScoped<EventsView>();
-        services.AddScoped<IEventsViewModel, EventsViewModel>();
+        services.AddScoped<IEventsViewModel, MoqEventsViewModel>();
         services.AddScoped<SnoopView>();
         services.AddScoped<ISnoopViewModel, MoqSnoopViewModel>();
         services.AddScoped<IWindow, RevitLookupView>();

--- a/source/RevitLookup.UI.Demo/Mock/MoqEventsViewModel.cs
+++ b/source/RevitLookup.UI.Demo/Mock/MoqEventsViewModel.cs
@@ -1,0 +1,47 @@
+﻿using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+using RevitLookup.Services;
+using RevitLookup.ViewModels.Contracts;
+using RevitLookup.ViewModels.Pages;
+
+namespace RevitLookup.UI.Demo.Mock;
+
+public sealed class MoqEventsViewModel : SnoopViewModelBase, IEventsViewModel
+{
+    private readonly Stack<SnoopableObject> _events = new();
+
+    public MoqEventsViewModel(NotificationService notificationService, IServiceProvider provider) : base(notificationService, provider)
+    {
+    }
+
+    public void OnNavigatedTo()
+    {
+        PushEvent("Subscribe", new EventArgs());
+    }
+
+    public void OnNavigatedFrom()
+    {
+        PushEvent("Unsubscribe", new EventArgs());
+    }
+
+    private void PushEvent(string name, EventArgs _event)
+    {
+        var snoopableObject = new SnoopableObject(_event)
+        {
+            Descriptor =
+            {
+                Name = $"{name} {DateTime.Now:HH:mm:ss}"
+            }
+        };
+
+        _events.Push(snoopableObject);
+        SnoopableObjects = new List<SnoopableObject>(_events);
+
+        //Object lifecycle expires. We should force a data retrieval before the object is cleared from memory
+        var descriptors = snoopableObject.GetMembers();
+        foreach (var descriptor in descriptors)
+            if (descriptor.Value.Descriptor is IDescriptorCollector)
+                descriptor.Value.GetMembers();
+    }
+}
+

--- a/source/RevitLookup/Core/EventMonitor.cs
+++ b/source/RevitLookup/Core/EventMonitor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -54,12 +54,12 @@ public sealed class EventMonitor
 
     public void Subscribe()
     {
-        Application.ActionEventHandler.Raise(Subscribe);
+        Application.ActionEventHandler?.Raise(Subscribe);
     }
 
     public void Unsubscribe()
     {
-        Application.ActionEventHandler.Raise(Unsubscribe);
+        Application.ActionEventHandler?.Raise(Unsubscribe);
     }
 
     private void Subscribe(UIApplication uiApplication)
@@ -67,26 +67,26 @@ public sealed class EventMonitor
         if (_eventInfos.Count > 0) return;
 
         foreach (var dll in _assemblies)
-        foreach (var type in dll.GetTypes())
-        foreach (var eventInfo in type.GetEvents())
-        {
-            Debug.Write($"RevitLookup EventMonitor: {eventInfo.ReflectedType}.{eventInfo.Name}");
-            if (_denyList.Contains(eventInfo.Name)) continue;
+            foreach (var type in dll.GetTypes())
+                foreach (var eventInfo in type.GetEvents())
+                {
+                    Debug.Write($"RevitLookup EventMonitor: {eventInfo.ReflectedType}.{eventInfo.Name}");
+                    if (_denyList.Contains(eventInfo.Name)) continue;
 
-            var targets = FindValidTargets(eventInfo.ReflectedType);
-            if (targets is null)
-            {
-                Debug.WriteLine(" - missing target");
-                break;
-            }
+                    var targets = FindValidTargets(eventInfo.ReflectedType);
+                    if (targets is null)
+                    {
+                        Debug.WriteLine(" - missing target");
+                        break;
+                    }
 
-            var methodInfo = GetType().GetMethod(nameof(OnHandlingEvent), BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
-            var eventHandler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, methodInfo);
+                    var methodInfo = GetType().GetMethod(nameof(OnHandlingEvent), BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
+                    var eventHandler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, methodInfo);
 
-            foreach (var target in targets) eventInfo.AddEventHandler(target, eventHandler);
-            _eventInfos.Add(eventInfo, eventHandler);
-            Debug.WriteLine(" - success");
-        }
+                    foreach (var target in targets) eventInfo.AddEventHandler(target, eventHandler);
+                    _eventInfos.Add(eventInfo, eventHandler);
+                    Debug.WriteLine(" - success");
+                }
     }
 
     private void Unsubscribe(UIApplication _)
@@ -103,8 +103,8 @@ public sealed class EventMonitor
     private static IEnumerable FindValidTargets(Type targetType)
     {
         if (targetType == typeof(Document)) return RevitApi.Application.Documents;
-        if (targetType == typeof(Autodesk.Revit.ApplicationServices.Application)) return new[] {RevitApi.Application};
-        if (targetType == typeof(UIApplication)) return new[] {RevitApi.UiApplication};
+        if (targetType == typeof(Autodesk.Revit.ApplicationServices.Application)) return new[] { RevitApi.Application };
+        if (targetType == typeof(UIApplication)) return new[] { RevitApi.UiApplication };
 
         return null;
     }

--- a/source/RevitLookup/Core/EventMonitor.cs
+++ b/source/RevitLookup/Core/EventMonitor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -54,12 +54,12 @@ public sealed class EventMonitor
 
     public void Subscribe()
     {
-        Application.ActionEventHandler?.Raise(Subscribe);
+        Application.ActionEventHandler.Raise(Subscribe);
     }
 
     public void Unsubscribe()
     {
-        Application.ActionEventHandler?.Raise(Unsubscribe);
+        Application.ActionEventHandler.Raise(Unsubscribe);
     }
 
     private void Subscribe(UIApplication uiApplication)

--- a/source/RevitLookup/Core/EventMonitor.cs
+++ b/source/RevitLookup/Core/EventMonitor.cs
@@ -1,4 +1,4 @@
-// Copyright 2003-2023 by Autodesk, Inc.
+﻿// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -67,26 +67,26 @@ public sealed class EventMonitor
         if (_eventInfos.Count > 0) return;
 
         foreach (var dll in _assemblies)
-            foreach (var type in dll.GetTypes())
-                foreach (var eventInfo in type.GetEvents())
-                {
-                    Debug.Write($"RevitLookup EventMonitor: {eventInfo.ReflectedType}.{eventInfo.Name}");
-                    if (_denyList.Contains(eventInfo.Name)) continue;
+        foreach (var type in dll.GetTypes())
+        foreach (var eventInfo in type.GetEvents())
+        {
+            Debug.Write($"RevitLookup EventMonitor: {eventInfo.ReflectedType}.{eventInfo.Name}");
+            if (_denyList.Contains(eventInfo.Name)) continue;
 
-                    var targets = FindValidTargets(eventInfo.ReflectedType);
-                    if (targets is null)
-                    {
-                        Debug.WriteLine(" - missing target");
-                        break;
-                    }
+            var targets = FindValidTargets(eventInfo.ReflectedType);
+            if (targets is null)
+            {
+                Debug.WriteLine(" - missing target");
+                break;
+            }
 
-                    var methodInfo = GetType().GetMethod(nameof(OnHandlingEvent), BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
-                    var eventHandler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, methodInfo);
+            var methodInfo = GetType().GetMethod(nameof(OnHandlingEvent), BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
+            var eventHandler = Delegate.CreateDelegate(eventInfo.EventHandlerType, this, methodInfo);
 
-                    foreach (var target in targets) eventInfo.AddEventHandler(target, eventHandler);
-                    _eventInfos.Add(eventInfo, eventHandler);
-                    Debug.WriteLine(" - success");
-                }
+            foreach (var target in targets) eventInfo.AddEventHandler(target, eventHandler);
+            _eventInfos.Add(eventInfo, eventHandler);
+            Debug.WriteLine(" - success");
+        }
     }
 
     private void Unsubscribe(UIApplication _)
@@ -103,8 +103,8 @@ public sealed class EventMonitor
     private static IEnumerable FindValidTargets(Type targetType)
     {
         if (targetType == typeof(Document)) return RevitApi.Application.Documents;
-        if (targetType == typeof(Autodesk.Revit.ApplicationServices.Application)) return new[] { RevitApi.Application };
-        if (targetType == typeof(UIApplication)) return new[] { RevitApi.UiApplication };
+        if (targetType == typeof(Autodesk.Revit.ApplicationServices.Application)) return new[] {RevitApi.Application};
+        if (targetType == typeof(UIApplication)) return new[] {RevitApi.UiApplication};
 
         return null;
     }

--- a/source/RevitLookup/Host.cs
+++ b/source/RevitLookup/Host.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Versioning;
@@ -60,7 +60,7 @@ public static class Host
         services.AddScoped<SettingsView>();
         services.AddScoped<SettingsViewModel>();
         services.AddScoped<EventsView>();
-        services.AddScoped<EventsViewModel>();
+        services.AddScoped<IEventsViewModel, EventsViewModel>();
         services.AddScoped<SnoopView>();
         services.AddScoped<ISnoopViewModel, SnoopViewModel>();
         services.AddScoped<IWindow, RevitLookupView>();

--- a/source/RevitLookup/ViewModels/Contracts/IEventsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Contracts/IEventsViewModel.cs
@@ -22,7 +22,4 @@ using Wpf.Ui.Controls;
 
 namespace RevitLookup.ViewModels.Contracts;
 
-public interface IEventsViewModel : INavigationAware, ISnoopViewModel
-{
-
-}
+public interface IEventsViewModel : INavigationAware, ISnoopViewModel;

--- a/source/RevitLookup/ViewModels/Contracts/IEventsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Contracts/IEventsViewModel.cs
@@ -18,21 +18,11 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
-using CommunityToolkit.Mvvm.Input;
-using RevitLookup.Core.Objects;
+using Wpf.Ui.Controls;
 
 namespace RevitLookup.ViewModels.Contracts;
 
-public interface ISnoopViewModel
+public interface IEventsViewModel : INavigationAware, ISnoopViewModel
 {
-    IReadOnlyCollection<SnoopableObject> SnoopableObjects { get; set; }
-    IReadOnlyCollection<Descriptor> SnoopableData { get; set; }
-    IReadOnlyCollection<SnoopableObject> FilteredSnoopableObjects { get; }
-    IReadOnlyCollection<Descriptor> FilteredSnoopableData { get; }
-    IAsyncRelayCommand FetchMembersCommand { get; }
-    IAsyncRelayCommand RefreshMembersCommand { get; }
-    public string SearchText { get; set; }
-    public SnoopableObject SelectedObject { get; set; }
-    void Navigate(SnoopableObject selectedItem);
-    void Navigate(IReadOnlyCollection<SnoopableObject> selectedItems);
+
 }

--- a/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
@@ -27,11 +27,6 @@ using Wpf.Ui.Controls;
 
 namespace RevitLookup.ViewModels.Pages;
 
-public interface IEventsViewModel : INavigationAware, ISnoopViewModel
-{
-
-}
-
 public sealed class EventsViewModel : SnoopViewModelBase, INavigationAware, IEventsViewModel
 {
     private readonly EventMonitor _eventMonitor;

--- a/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2023 by Autodesk, Inc.
+// Copyright 2003-2023 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -22,11 +22,18 @@ using RevitLookup.Core;
 using RevitLookup.Core.Contracts;
 using RevitLookup.Core.Objects;
 using RevitLookup.Services;
+using RevitLookup.ViewModels.Contracts;
 using Wpf.Ui.Controls;
 
 namespace RevitLookup.ViewModels.Pages;
 
-public sealed class EventsViewModel : SnoopViewModelBase, INavigationAware
+public interface IEventsViewModel : ISnoopViewModel
+{
+    void OnNavigatedTo();
+    void OnNavigatedFrom();
+}
+
+public sealed class EventsViewModel : SnoopViewModelBase, INavigationAware, IEventsViewModel
 {
     private readonly EventMonitor _eventMonitor;
     private readonly Stack<SnoopableObject> _events = new();

--- a/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
@@ -27,10 +27,9 @@ using Wpf.Ui.Controls;
 
 namespace RevitLookup.ViewModels.Pages;
 
-public interface IEventsViewModel : ISnoopViewModel
+public interface IEventsViewModel : INavigationAware, ISnoopViewModel
 {
-    void OnNavigatedTo();
-    void OnNavigatedFrom();
+
 }
 
 public sealed class EventsViewModel : SnoopViewModelBase, INavigationAware, IEventsViewModel

--- a/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Pages/EventsViewModel.cs
@@ -27,7 +27,7 @@ using Wpf.Ui.Controls;
 
 namespace RevitLookup.ViewModels.Pages;
 
-public sealed class EventsViewModel : SnoopViewModelBase, INavigationAware, IEventsViewModel
+public sealed class EventsViewModel : SnoopViewModelBase, IEventsViewModel
 {
     private readonly EventMonitor _eventMonitor;
     private readonly Stack<SnoopableObject> _events = new();

--- a/source/RevitLookup/Views/Pages/EventsView.xaml.cs
+++ b/source/RevitLookup/Views/Pages/EventsView.xaml.cs
@@ -19,6 +19,7 @@
 // (Rights in Technical Data and Computer Software), as applicable.
 
 using RevitLookup.Services.Contracts;
+using RevitLookup.ViewModels.Contracts;
 using RevitLookup.ViewModels.Pages;
 
 namespace RevitLookup.Views.Pages;

--- a/source/RevitLookup/Views/Pages/EventsView.xaml.cs
+++ b/source/RevitLookup/Views/Pages/EventsView.xaml.cs
@@ -25,7 +25,7 @@ namespace RevitLookup.Views.Pages;
 
 public sealed partial class EventsView
 {
-    public EventsView(EventsViewModel viewModel,  ISettingsService settingsService) : base(settingsService)
+    public EventsView(IEventsViewModel viewModel,  ISettingsService settingsService) : base(settingsService)
     {
         InitializeComponent();
         ViewModel = viewModel;


### PR DESCRIPTION
# Summary of the Pull Request

When using `UI.Demo` the `Application.ActionEventHandler` is null.

The `EventMonitor.Subscribe` and `EventMonitor.Unsubscribe` throw exception.

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings