### PR TITLE
Apply Theme updates each Windows

### DIFF
--- a/source/RevitLookup.UI/Appearance/ApplicationThemeManager.cs
+++ b/source/RevitLookup.UI/Appearance/ApplicationThemeManager.cs
@@ -69,86 +69,94 @@ public static class ApplicationThemeManager
         bool updateAccent = true,
         bool forceBackground = false)
     {
-        if (updateAccent)
+        var mainWindow = Application.MainWindow;
+
+        foreach (var window in Application.Windows)
         {
-            ApplicationAccentColorManager.Apply(ApplicationAccentColorManager.GetColorizationColor(),
-                applicationTheme,
-                false
+            Application.MainWindow = window;
+
+            if (updateAccent)
+            {
+                ApplicationAccentColorManager.Apply(ApplicationAccentColorManager.GetColorizationColor(),
+                    applicationTheme,
+                    false
+                );
+            }
+
+            if (applicationTheme == ApplicationTheme.Unknown)
+            {
+                return;
+            }
+
+            var appDictionaries = new ResourceDictionaryManager(LibraryNamespace);
+
+            var themeDictionaryName = "Light";
+
+            switch (applicationTheme)
+            {
+                case ApplicationTheme.Dark:
+                    themeDictionaryName = "Dark";
+                    break;
+                case ApplicationTheme.HighContrast:
+                    switch (ApplicationThemeManager.GetSystemTheme())
+                    {
+                        case SystemTheme.HC1:
+                            themeDictionaryName = "HC1";
+                            break;
+                        case SystemTheme.HC2:
+                            themeDictionaryName = "HC2";
+                            break;
+                        case SystemTheme.HCBlack:
+                            themeDictionaryName = "HCBlack";
+                            break;
+                        case SystemTheme.HCWhite:
+                        default:
+                            themeDictionaryName = "HCWhite";
+                            break;
+                    }
+
+                    break;
+            }
+
+            var isUpdated = appDictionaries.UpdateDictionary("theme",
+                new Uri(ThemesDictionaryPath + themeDictionaryName + ".xaml", UriKind.Absolute)
             );
+
+            //var wpfUiDictionary = appDictionaries.GetDictionary("wpf.ui");
+
+            // Force reloading ALL dictionaries
+            // Works but is terrible
+            //var isCoreUpdated = appDictionaries.UpdateDictionary(
+            //    "wpf.ui",
+            //    new Uri(
+            //        AppearanceData.LibraryDictionariesUri + "Wpf.Ui.xaml",
+            //        UriKind.Absolute
+            //    )
+            //);
+
+            //var isBrushesUpdated = appDictionaries.UpdateDictionary(
+            //        "assets/brushes",
+            //        new Uri(
+            //            AppearanceData.LibraryDictionariesUri + "Assets/Brushes.xaml",
+            //            UriKind.Absolute
+            //        )
+            //    );
+
+    #if DEBUG
+            System
+                .Diagnostics
+                .Debug
+                .WriteLine(
+                    $"INFO | {typeof(ApplicationThemeManager)} tries to update theme to {themeDictionaryName} ({applicationTheme}): {isUpdated}",
+                    nameof(ApplicationThemeManager)
+                );
+    #endif
+            if (!isUpdated)
+            {
+                return;
+            }
         }
-
-        if (applicationTheme == ApplicationTheme.Unknown)
-        {
-            return;
-        }
-
-        var appDictionaries = new ResourceDictionaryManager(LibraryNamespace);
-
-        var themeDictionaryName = "Light";
-
-        switch (applicationTheme)
-        {
-            case ApplicationTheme.Dark:
-                themeDictionaryName = "Dark";
-                break;
-            case ApplicationTheme.HighContrast:
-                switch (ApplicationThemeManager.GetSystemTheme())
-                {
-                    case SystemTheme.HC1:
-                        themeDictionaryName = "HC1";
-                        break;
-                    case SystemTheme.HC2:
-                        themeDictionaryName = "HC2";
-                        break;
-                    case SystemTheme.HCBlack:
-                        themeDictionaryName = "HCBlack";
-                        break;
-                    case SystemTheme.HCWhite:
-                    default:
-                        themeDictionaryName = "HCWhite";
-                        break;
-                }
-
-                break;
-        }
-
-        var isUpdated = appDictionaries.UpdateDictionary("theme",
-            new Uri(ThemesDictionaryPath + themeDictionaryName + ".xaml", UriKind.Absolute)
-        );
-
-        //var wpfUiDictionary = appDictionaries.GetDictionary("wpf.ui");
-
-        // Force reloading ALL dictionaries
-        // Works but is terrible
-        //var isCoreUpdated = appDictionaries.UpdateDictionary(
-        //    "wpf.ui",
-        //    new Uri(
-        //        AppearanceData.LibraryDictionariesUri + "Wpf.Ui.xaml",
-        //        UriKind.Absolute
-        //    )
-        //);
-
-        //var isBrushesUpdated = appDictionaries.UpdateDictionary(
-        //        "assets/brushes",
-        //        new Uri(
-        //            AppearanceData.LibraryDictionariesUri + "Assets/Brushes.xaml",
-        //            UriKind.Absolute
-        //        )
-        //    );
-
-#if DEBUG
-        System
-            .Diagnostics
-            .Debug
-            .WriteLine(
-                $"INFO | {typeof(ApplicationThemeManager)} tries to update theme to {themeDictionaryName} ({applicationTheme}): {isUpdated}",
-                nameof(ApplicationThemeManager)
-            );
-#endif
-        if (!isUpdated)
-        {
-            return;
-        }
+        Application.MainWindow = mainWindow; // Restore MainWindow
 
         SystemThemeManager.UpdateSystemThemeCache();
 
@@ -156,15 +164,21 @@ public static class ApplicationThemeManager
 
         Changed?.Invoke(applicationTheme, ApplicationAccentColorManager.SystemAccent);
 
-        if (Application.MainWindow is not null)
+        foreach (var window in Application.Windows)
         {
-            WindowBackgroundManager.UpdateBackground(
-                Application.MainWindow,
-                applicationTheme,
-                backgroundEffect,
-                forceBackground
-            );
+            Application.MainWindow = window;
+
+            if (Application.MainWindow is not null)
+            {
+                WindowBackgroundManager.UpdateBackground(
+                    Application.MainWindow,
+                    applicationTheme,
+                    backgroundEffect,
+                    forceBackground
+                );
+            }
         }
+        Application.MainWindow = mainWindow; // Restore MainWindow
     }
 
     public static void ApplySystemTheme()


### PR DESCRIPTION
# Summary of the Pull Request

When the theme changes to light/dark all the RevitLookUp windows update the theme.

https://github.com/jeremytammik/RevitLookup/assets/12437519/36e1b07b-9781-4052-9ebb-486022db9229

Tested in Window 10 - #194

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings