### PR TITLE
Add support for LocationCurve overloading properties

### DIFF
--- a/source/RevitLookup/Core/ComponentModel/DescriptorMap.cs
+++ b/source/RevitLookup/Core/ComponentModel/DescriptorMap.cs
@@ -80,6 +80,7 @@ public static class DescriptorMap
             DefinitionGroup value when type is null || type == typeof(DefinitionGroup) => new DefinitionGroupDescriptor(value),
             FamilyManager value when type is null || type == typeof(FamilyManager) => new FamilyManagerDescriptor(value),
             MEPSection value when type is null || type == typeof(MEPSection) => new MepSectionDescriptor(value),
+            LocationCurve value when type is null || type == typeof(LocationCurve) => new LocationCurveDescriptor(value),
             APIObject when type is null || type == typeof(APIObject) => new ApiObjectDescriptor(),
 
             //IDisposables

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/LocationCurveDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/LocationCurveDescriptor.cs
@@ -1,0 +1,63 @@
+// Copyright 2003-2024 by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using System.Reflection;
+using Autodesk.Revit.DB;
+using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public class LocationCurveDescriptor(LocationCurve locationCurve) : Descriptor, IDescriptorResolver
+{
+    public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
+    {
+        return target switch
+        {
+            "ElementsAtJoin" => ResolveElementsAtJoin(),
+            "JoinType" => ResolveJoinType(),
+            _ => null
+        };
+
+        ResolveSet ResolveElementsAtJoin()
+        {
+            var resolveSummary = new ResolveSet(2);
+            for (var i = 0; i < 2; i++)
+            {
+                var elements = locationCurve.get_ElementsAtJoin(i);
+                resolveSummary.AppendVariant(elements, $"Point {i}");
+            }
+
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveJoinType()
+        {
+            var resolveSummary = new ResolveSet(2);
+            for (var i = 0; i < 2; i++)
+            {
+                var joinType = locationCurve.get_JoinType(i);
+                resolveSummary.AppendVariant(joinType, $"Point {i}");
+            }
+        
+            return resolveSummary;
+        }
+    }
+}


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 

I added support for JoinType and ElementsAtJoin properties of LocationCurve class

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings