### PR TITLE
add support for static IsLoaded of RevitLinkType

### DIFF
--- a/source/RevitLookup/Core/ComponentModel/Descriptors/RevitLinkTypeDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/RevitLinkTypeDescriptor.cs
@@ -27,12 +27,15 @@ namespace RevitLookup.Core.ComponentModel.Descriptors;
 
 public sealed class RevitLinkTypeDescriptor(Element element) : ElementDescriptor(element), IDescriptorResolver
 {
+    private readonly Element _element = element;
+
     public new ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
     {
         return target switch
         {
             nameof(RevitLinkType.Load) => ResolveSet.Append(new LinkLoadResult(), "Overridden"),
             nameof(RevitLinkType.Reload) => ResolveSet.Append(new LinkLoadResult(), "Overridden"),
+            nameof(RevitLinkType.IsLoaded) => ResolveSet.Append(RevitLinkType.IsLoaded(_element.Document, _element.Id)),
             _ => null
         };
     }


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 

I added support of static method IsLoaded of RevitLinkType class. After that Rider gives a warning "Parameter 'element' is captured into the state of the enclosing type and its value is also passed to the base constructor. The value might be captured by the base class as well", so I added readonly field like in base class ElementDescriptor

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings