### PR TITLE
Add TableSectionData support

### DIFF
--- a/source/RevitLookup/Core/ComponentModel/DescriptorMap.cs
+++ b/source/RevitLookup/Core/ComponentModel/DescriptorMap.cs
@@ -116,6 +116,7 @@ public static class DescriptorMap
             ViewSchedule value when type == typeof(ViewSchedule) => new ViewScheduleDescriptor(value),
             ScheduleDefinition value when type == typeof(ScheduleDefinition) => new ScheduleDefinitionDescriptor(value),
             TableData value when type == typeof(TableData) => new TableDataDescriptor(value),
+            TableSectionData value when type == typeof(TableSectionData) => new TableSectionDataDescriptor(value),
 #if REVIT2024_OR_GREATER
             EvaluatedParameter value when type is null || type == typeof(EvaluatedParameter) => new EvaluatedParameterDescriptor(value),
 #endif

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/TableSectionDataDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/TableSectionDataDescriptor.cs
@@ -36,14 +36,20 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             nameof(TableSectionData.CanInsertRow) => ResolveCanInsertRow(),
             nameof(TableSectionData.CanRemoveColumn) => ResolveCanRemoveColumn(),
             nameof(TableSectionData.CanRemoveRow) => ResolveCanRemoveRow(),
-            nameof(TableSectionData.GetCellCalculatedValue) => ResolveCellCalculatedValue(),
-            nameof(TableSectionData.GetCellCategoryId) => ResolveCellCategoryId(),
-            nameof(TableSectionData.GetCellCombinedParameters) => ResolveCellCombinedParameters(),
-            nameof(TableSectionData.GetCellFormatOptions) => ResolveCellFormatOptions(),
-            nameof(TableSectionData.GetCellParamId) => ResolveCellParamId(),
+            nameof(TableSectionData.GetCellCalculatedValue) when parameters.Length == 1 => ResolveCellCalculatedValueForColumns(),
+            nameof(TableSectionData.GetCellCalculatedValue) when parameters.Length == 2 => ResolveCellCalculatedValueForTable(),
+            nameof(TableSectionData.GetCellCategoryId) when parameters.Length == 1 => ResolveCellCategoryIdForColumns(),
+            nameof(TableSectionData.GetCellCategoryId) when parameters.Length == 2 => ResolveCellCategoryIdForTable(),
+            nameof(TableSectionData.GetCellCombinedParameters) when parameters.Length == 1 => ResolveCellCombinedParametersForColumns(),
+            nameof(TableSectionData.GetCellCombinedParameters) when parameters.Length == 2 => ResolveCellCombinedParametersForTable(),
+            nameof(TableSectionData.GetCellFormatOptions) when parameters.Length == 2 => ResolveCellFormatOptionsForColumns(),
+            nameof(TableSectionData.GetCellFormatOptions) when parameters.Length == 3 => ResolveCellFormatOptionsForTable(),
+            nameof(TableSectionData.GetCellParamId) when parameters.Length == 1 => ResolveCellParamIdForColumns(),
+            nameof(TableSectionData.GetCellParamId) when parameters.Length == 2 => ResolveCellParamIdForTable(),
             nameof(TableSectionData.GetCellSpec) => ResolveCellSpec(),
             nameof(TableSectionData.GetCellText) => ResolveCellText(),
-            nameof(TableSectionData.GetCellType) => ResolveCellType(),
+            nameof(TableSectionData.GetCellType) when parameters.Length == 1 => ResolveCellTypeForColumns(),
+            nameof(TableSectionData.GetCellType) when parameters.Length == 2 => ResolveCellTypeForTable(),
             nameof(TableSectionData.GetRowHeight) => ResolveRowHeight(),
             nameof(TableSectionData.RefreshData) => ResolveSet.Append(false, "Overridden"),
             _ => null
@@ -69,8 +75,8 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
         ResolveSet ResolveCanInsertColumn()
         {
             var count = tableSectionData.NumberOfColumns;
-            var resolveSummary = new ResolveSet(count + 2);
-            for (var i = 0; i < count + 2; i++)
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
             {
                 var result = tableSectionData.CanInsertColumn(i);
                 resolveSummary.AppendVariant(result, $"{i}: {result}");
@@ -82,8 +88,8 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
         ResolveSet ResolveCanInsertRow()
         {
             var count = tableSectionData.NumberOfRows;
-            var resolveSummary = new ResolveSet(count + 2);
-            for (var i = 0; i < count + 2; i++)
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
             {
                 var result = tableSectionData.CanInsertRow(i);
                 resolveSummary.AppendVariant(result, $"{i}: {result}");
@@ -118,7 +124,20 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             return resolveSummary;
         }
         
-        ResolveSet ResolveCellCalculatedValue()
+        ResolveSet ResolveCellCalculatedValueForColumns()
+        {
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(columnsNumber);
+            for (var j = 0; j < columnsNumber; j++)
+            {
+                var result = tableSectionData.GetCellCalculatedValue(j);
+                resolveSummary.AppendVariant(result, $"Column {j}: {result}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellCalculatedValueForTable()
         {
             var rowsNumber = tableSectionData.NumberOfRows;
             var columnsNumber = tableSectionData.NumberOfColumns;
@@ -135,23 +154,33 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             return resolveSummary;
         }
         
-        ResolveSet ResolveCellCategoryId()
+        ResolveSet ResolveCellCategoryIdForColumns()
+        {
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var result = tableSectionData.GetCellCategoryId(i);
+                if (result != ElementId.InvalidElementId)
+                {
+                    var category = Category.GetCategory(context, result);
+                    if (category is not null)
+                    {
+                        resolveSummary.AppendVariant(result, $"Column {i}: {category.Name}");
+                    }
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellCategoryIdForTable()
         {
             var rowsNumber = tableSectionData.NumberOfRows;
             var columnsNumber = tableSectionData.NumberOfColumns;
             var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
             for (var i = 0; i < columnsNumber; i++)
             {
-                var columnResult = tableSectionData.GetCellCategoryId(i);
-                if (columnResult != ElementId.InvalidElementId)
-                {
-                    var category = Category.GetCategory(context, columnResult);
-                    if (category is not null)
-                    {
-                        resolveSummary.AppendVariant(columnResult, $"Column {i}: {category.Name}");
-                    }
-                }
-                
                 for (var j = 0; j < rowsNumber; j++)
                 {
                     var result = tableSectionData.GetCellCategoryId(j, i);
@@ -169,15 +198,26 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             return resolveSummary;
         }
         
-        ResolveSet ResolveCellCombinedParameters()
+        ResolveSet ResolveCellCombinedParametersForColumns()
+        {
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var result = tableSectionData.GetCellCombinedParameters(i);
+                resolveSummary.AppendVariant(result, $"Column {i}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellCombinedParametersForTable()
         {
             var rowsNumber = tableSectionData.NumberOfRows;
             var columnsNumber = tableSectionData.NumberOfColumns;
             var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
             for (var i = 0; i < columnsNumber; i++)
             {
-                var columnResult = tableSectionData.GetCellCombinedParameters(i);
-                resolveSummary.AppendVariant(columnResult, $"Column {i}");
                 for (var j = 0; j < rowsNumber; j++)
                 {
                     var result = tableSectionData.GetCellCombinedParameters(j, i);
@@ -188,15 +228,26 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             return resolveSummary;
         }
         
-        ResolveSet ResolveCellFormatOptions()
+        ResolveSet ResolveCellFormatOptionsForColumns()
+        {
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var result = tableSectionData.GetCellFormatOptions(i, context);
+                resolveSummary.AppendVariant(result, $"Column {i}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellFormatOptionsForTable()
         {
             var rowsNumber = tableSectionData.NumberOfRows;
             var columnsNumber = tableSectionData.NumberOfColumns;
             var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
             for (var i = 0; i < columnsNumber; i++)
             {
-                var columnResult = tableSectionData.GetCellFormatOptions(i, context);
-                resolveSummary.AppendVariant(columnResult, $"Column {i}");
                 for (var j = 0; j < rowsNumber; j++)
                 {
                     var result = tableSectionData.GetCellFormatOptions(j, i, context);
@@ -207,20 +258,30 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             return resolveSummary;
         }
         
-        ResolveSet ResolveCellParamId()
+        ResolveSet ResolveCellParamIdForColumns()
+        {
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var result = tableSectionData.GetCellParamId(i);
+                if (result != ElementId.InvalidElementId)
+                {
+                    var parameter = result.ToElement(context);
+                    resolveSummary.AppendVariant(result, $"Column {i}: {parameter!.Name}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellParamIdForTable()
         {
             var rowsNumber = tableSectionData.NumberOfRows;
             var columnsNumber = tableSectionData.NumberOfColumns;
             var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
             for (var i = 0; i < columnsNumber; i++)
             {
-                var columnResult = tableSectionData.GetCellParamId(i);
-                if (columnResult != ElementId.InvalidElementId)
-                {
-                    var parameter = columnResult.ToElement(context);
-                    resolveSummary.AppendVariant(columnResult, $"Column {i}: {parameter!.Name}");
-                }
-                
                 for (var j = 0; j < rowsNumber; j++)
                 {
                     var result = tableSectionData.GetCellParamId(j, i);
@@ -246,7 +307,7 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
                 {
                     var result = tableSectionData.GetCellSpec(j, i);
                     if (!result.Empty())
-                        resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {result.ToLabel()}");
+                        resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {result.ToUnitLabel()}");
                 }
             }
             
@@ -270,15 +331,26 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             return resolveSummary;
         }
         
-        ResolveSet ResolveCellType()
+        ResolveSet ResolveCellTypeForColumns()
+        {
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var columnResult = tableSectionData.GetCellType(i);
+                resolveSummary.AppendVariant(columnResult, $"Column {i}: {columnResult}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellTypeForTable()
         {
             var rowsNumber = tableSectionData.NumberOfRows;
             var columnsNumber = tableSectionData.NumberOfColumns;
             var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
             for (var i = 0; i < columnsNumber; i++)
             {
-                var columnResult = tableSectionData.GetCellType(i);
-                resolveSummary.AppendVariant(columnResult, $"Column {i}: {columnResult}");
                 for (var j = 0; j < rowsNumber; j++)
                 {
                     var result = tableSectionData.GetCellType(j, i);

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/TableSectionDataDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/TableSectionDataDescriptor.cs
@@ -1,0 +1,305 @@
+// Copyright 2003-2024 by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using System.Globalization;
+using System.Reflection;
+using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Descriptor, IDescriptorResolver
+{
+    public ResolveSet Resolve(Document context, string target, ParameterInfo[] parameters)
+    {
+        return target switch
+        {
+            nameof(TableSectionData.AllowOverrideCellStyle) => ResolveOverrideCellStyle(),
+            nameof(TableSectionData.CanInsertColumn) => ResolveCanInsertColumn(),
+            nameof(TableSectionData.CanInsertRow) => ResolveCanInsertRow(),
+            nameof(TableSectionData.CanRemoveColumn) => ResolveCanRemoveColumn(),
+            nameof(TableSectionData.CanRemoveRow) => ResolveCanRemoveRow(),
+            nameof(TableSectionData.GetCellCalculatedValue) => ResolveCellCalculatedValue(),
+            nameof(TableSectionData.GetCellCategoryId) => ResolveCellCategoryId(),
+            nameof(TableSectionData.GetCellCombinedParameters) => ResolveCellCombinedParameters(),
+            nameof(TableSectionData.GetCellFormatOptions) => ResolveCellFormatOptions(),
+            nameof(TableSectionData.GetCellParamId) => ResolveCellParamId(),
+            nameof(TableSectionData.GetCellSpec) => ResolveCellSpec(),
+            nameof(TableSectionData.GetCellText) => ResolveCellText(),
+            nameof(TableSectionData.GetCellType) => ResolveCellType(),
+            nameof(TableSectionData.GetRowHeight) => ResolveRowHeight(),
+            nameof(TableSectionData.RefreshData) => ResolveSet.Append(false, "Overridden"),
+            _ => null
+        };
+        
+        ResolveSet ResolveOverrideCellStyle()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < rowsNumber; i++)
+            {
+                for (var j = 0; j < columnsNumber; j++)
+                {
+                    var result = tableSectionData.AllowOverrideCellStyle(i, j);
+                    resolveSummary.AppendVariant(result, $"Row {i}, Column {j}: {result}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCanInsertColumn()
+        {
+            var count = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(count + 2);
+            for (var i = 0; i < count + 2; i++)
+            {
+                var result = tableSectionData.CanInsertColumn(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCanInsertRow()
+        {
+            var count = tableSectionData.NumberOfRows;
+            var resolveSummary = new ResolveSet(count + 2);
+            for (var i = 0; i < count + 2; i++)
+            {
+                var result = tableSectionData.CanInsertRow(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCanRemoveColumn()
+        {
+            var count = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.CanRemoveColumn(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCanRemoveRow()
+        {
+            var count = tableSectionData.NumberOfRows;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.CanRemoveRow(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellCalculatedValue()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < rowsNumber; i++)
+            {
+                for (var j = 0; j < columnsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellCalculatedValue(i, j);
+                    resolveSummary.AppendVariant(result, $"Row {i}, Column {j}: {result}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellCategoryId()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var columnResult = tableSectionData.GetCellCategoryId(i);
+                if (columnResult != ElementId.InvalidElementId)
+                {
+                    var category = Category.GetCategory(context, columnResult);
+                    if (category is not null)
+                    {
+                        resolveSummary.AppendVariant(columnResult, $"Column {i}: {category.Name}");
+                    }
+                }
+                
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellCategoryId(j, i);
+                    if (result != ElementId.InvalidElementId)
+                    {
+                        var category = Category.GetCategory(context, result);
+                        if (category is not null)
+                        {
+                            resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {category.Name}");
+                        }
+                    }
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellCombinedParameters()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var columnResult = tableSectionData.GetCellCombinedParameters(i);
+                resolveSummary.AppendVariant(columnResult, $"Column {i}");
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellCombinedParameters(j, i);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellFormatOptions()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var columnResult = tableSectionData.GetCellFormatOptions(i, context);
+                resolveSummary.AppendVariant(columnResult, $"Column {i}");
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellFormatOptions(j, i, context);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellParamId()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var columnResult = tableSectionData.GetCellParamId(i);
+                if (columnResult != ElementId.InvalidElementId)
+                {
+                    var parameter = columnResult.ToElement(context);
+                    resolveSummary.AppendVariant(columnResult, $"Column {i}: {parameter!.Name}");
+                }
+                
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellParamId(j, i);
+                    if (result != ElementId.InvalidElementId)
+                    {
+                        var parameter = result.ToElement(context);
+                        resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {parameter!.Name}");
+                    }
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellSpec()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellSpec(j, i);
+                    if (!result.Empty())
+                        resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {result.ToLabel()}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellText()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellText(j, i);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {result}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveCellType()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var columnResult = tableSectionData.GetCellType(i);
+                resolveSummary.AppendVariant(columnResult, $"Column {i}: {columnResult}");
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetCellType(j, i);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {result}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveRowHeight()
+        {
+            var count = tableSectionData.NumberOfRows;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.GetRowHeight(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result.ToString(CultureInfo.InvariantCulture)} ft");
+            }
+            
+            return resolveSummary;
+        }
+    }
+}

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/TableSectionDataDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/TableSectionDataDescriptor.cs
@@ -50,7 +50,17 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             nameof(TableSectionData.GetCellText) => ResolveCellText(),
             nameof(TableSectionData.GetCellType) when parameters.Length == 1 => ResolveCellTypeForColumns(),
             nameof(TableSectionData.GetCellType) when parameters.Length == 2 => ResolveCellTypeForTable(),
+            nameof(TableSectionData.GetColumnWidth) => ResolveColumnWidth(),
+            nameof(TableSectionData.GetColumnWidthInPixels) => ResolveColumnWidthInPixels(),
+            nameof(TableSectionData.GetMergedCell) => ResolveMergedCell(),
             nameof(TableSectionData.GetRowHeight) => ResolveRowHeight(),
+            nameof(TableSectionData.GetRowHeightInPixels) => ResolveRowHeightInPixels(),
+            nameof(TableSectionData.GetTableCellStyle) => ResolveTableCellStyle(),
+            nameof(TableSectionData.IsCellFormattable) => ResolveIsCellFormattable(),
+            nameof(TableSectionData.IsCellOverridden) when parameters.Length == 1 => ResolveIsCellOverriddenForColumns(),
+            nameof(TableSectionData.IsCellOverridden) when parameters.Length == 2 => ResolveIsCellOverriddenForTable(),
+            nameof(TableSectionData.IsValidColumnNumber) => ResolveIsValidColumnNumber(),
+            nameof(TableSectionData.IsValidRowNumber) => ResolveIsValidRowNumber(),
             nameof(TableSectionData.RefreshData) => ResolveSet.Append(false, "Overridden"),
             _ => null
         };
@@ -361,6 +371,50 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             return resolveSummary;
         }
         
+        ResolveSet ResolveColumnWidth()
+        {
+            var count = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.GetColumnWidth(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result.ToString(CultureInfo.InvariantCulture)} ft");
+            }
+            
+            return resolveSummary;
+        }
+        
+        
+        ResolveSet ResolveColumnWidthInPixels()
+        {
+            var count = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.GetColumnWidthInPixels(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result.ToString(CultureInfo.InvariantCulture)} px");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveMergedCell()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetMergedCell(j, i);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
         ResolveSet ResolveRowHeight()
         {
             var count = tableSectionData.NumberOfRows;
@@ -369,6 +423,109 @@ public class TableSectionDataDescriptor(TableSectionData tableSectionData) : Des
             {
                 var result = tableSectionData.GetRowHeight(i);
                 resolveSummary.AppendVariant(result, $"{i}: {result.ToString(CultureInfo.InvariantCulture)} ft");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveRowHeightInPixels()
+        {
+            var count = tableSectionData.NumberOfRows;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.GetRowHeightInPixels(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result.ToString(CultureInfo.InvariantCulture)} px");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveTableCellStyle()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.GetTableCellStyle(j, i);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveIsCellFormattable()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.IsCellFormattable(j, i);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {result}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveIsCellOverriddenForColumns()
+        {
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                var columnResult = tableSectionData.IsCellOverridden(i);
+                resolveSummary.AppendVariant(columnResult, $"Column {i}: {columnResult}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveIsCellOverriddenForTable()
+        {
+            var rowsNumber = tableSectionData.NumberOfRows;
+            var columnsNumber = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(rowsNumber * columnsNumber);
+            for (var i = 0; i < columnsNumber; i++)
+            {
+                for (var j = 0; j < rowsNumber; j++)
+                {
+                    var result = tableSectionData.IsCellOverridden(j, i);
+                    resolveSummary.AppendVariant(result, $"Row {j}, Column {i}: {result}");
+                }
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveIsValidColumnNumber()
+        {
+            var count = tableSectionData.NumberOfColumns;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.IsValidColumnNumber(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result}");
+            }
+            
+            return resolveSummary;
+        }
+        
+        ResolveSet ResolveIsValidRowNumber()
+        {
+            var count = tableSectionData.NumberOfRows;
+            var resolveSummary = new ResolveSet(count);
+            for (var i = 0; i < count; i++)
+            {
+                var result = tableSectionData.IsValidRowNumber(i);
+                resolveSummary.AppendVariant(result, $"{i}: {result}");
             }
             
             return resolveSummary;


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 

I added support for some methods of TableSectionData class. It contains a lot of code, so I desided to divide PR into parts, because I'm not sure that I write code in best way in all the methods. The main question is about methods like GetCellCategoryId, which has 2 signatures: only columns and columns with rows. I think that thr best way is to divide these methods into 2 Resolve methods, but I don't nkow how, because they have same names.

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings