### PR TITLE
Add extensions for Part class and associated classes

### DIFF
--- a/source/RevitLookup/Core/ComponentModel/DescriptorMap.cs
+++ b/source/RevitLookup/Core/ComponentModel/DescriptorMap.cs
@@ -111,6 +111,8 @@ public static class DescriptorMap
             InternalOrigin value when type is null || type == typeof(InternalOrigin) => new InternalOriginDescriptor(value),
             CurveElement value when type is null || type == typeof(CurveElement) => new CurveElementDescriptor(value),
             DatumPlane value when type is null || type == typeof(DatumPlane) => new DatumPlaneDescriptor(value),
+            Part value when type is null || type == typeof(Part) => new PartDescriptor(value),
+            PartMaker value when type is null || type == typeof(PartMaker) => new PartMakerDescriptor(value),
             Element value when type is null || type == typeof(Element) => new ElementDescriptor(value),
             
             //IDisposables

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/ElementDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/ElementDescriptor.cs
@@ -286,6 +286,8 @@ public class ElementDescriptor : Descriptor, IDescriptorResolver, IDescriptorCon
         manager.Register(nameof(SolidSolidCutUtils.GetSolidsBeingCut), _ => SolidSolidCutUtils.GetSolidsBeingCut(_element));
         manager.Register(nameof(SolidSolidCutUtils.IsAllowedForSolidCut), _ => SolidSolidCutUtils.IsAllowedForSolidCut(_element));
         manager.Register(nameof(SolidSolidCutUtils.IsElementFromAppropriateContext), _ => SolidSolidCutUtils.IsElementFromAppropriateContext(_element));
+        manager.Register(nameof(PartUtils.AreElementsValidForCreateParts), context => Variants.Single(PartUtils.AreElementsValidForCreateParts(context, [_element.Id])));
+
     }
 
     public virtual void RegisterMenu(ContextMenu contextMenu)

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/ElementDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/ElementDescriptor.cs
@@ -286,7 +286,7 @@ public class ElementDescriptor : Descriptor, IDescriptorResolver, IDescriptorCon
         manager.Register(nameof(SolidSolidCutUtils.GetSolidsBeingCut), _ => SolidSolidCutUtils.GetSolidsBeingCut(_element));
         manager.Register(nameof(SolidSolidCutUtils.IsAllowedForSolidCut), _ => SolidSolidCutUtils.IsAllowedForSolidCut(_element));
         manager.Register(nameof(SolidSolidCutUtils.IsElementFromAppropriateContext), _ => SolidSolidCutUtils.IsElementFromAppropriateContext(_element));
-        manager.Register(nameof(PartUtils.AreElementsValidForCreateParts), context => Variants.Single(PartUtils.AreElementsValidForCreateParts(context, [_element.Id])));
+        manager.Register(nameof(PartUtils.AreElementsValidForCreateParts), context => PartUtils.AreElementsValidForCreateParts(context, [_element.Id]));
 
     }
 

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/FamilyDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/FamilyDescriptor.cs
@@ -20,7 +20,6 @@
 
 using System.Reflection;
 using RevitLookup.Core.Contracts;
-using RevitLookup.Core.Objects;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
 
@@ -33,10 +32,6 @@ public sealed class FamilyDescriptor(Family family) : ElementDescriptor(family)
     
     public override void RegisterExtensions(IExtensionManager manager)
     {
-        manager.Register(nameof(FamilySizeTableManager.GetFamilySizeTableManager), context =>
-        {
-            var result = FamilySizeTableManager.GetFamilySizeTableManager(context, family.Id);
-            return Variants.Single(result);
-        });
+        manager.Register(nameof(FamilySizeTableManager.GetFamilySizeTableManager), context => FamilySizeTableManager.GetFamilySizeTableManager(context, family.Id));
     }
 }

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/PartDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/PartDescriptor.cs
@@ -18,9 +18,7 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
-using System.Windows.Controls;
 using RevitLookup.Core.Contracts;
-using RevitLookup.Core.Objects;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
 
@@ -28,22 +26,17 @@ public class PartDescriptor(Part part) : ElementDescriptor(part)
 {
     public override void RegisterExtensions(IExtensionManager manager)
     {
-        manager.Register(nameof(PartUtils.IsMergedPart), _ => Variants.Single(PartUtils.IsMergedPart(part)));
-        manager.Register(nameof(PartUtils.IsPartDerivedFromLink), _ => Variants.Single(PartUtils.IsPartDerivedFromLink(part)));
-        manager.Register(nameof(PartUtils.GetChainLengthToOriginal), _ => Variants.Single(PartUtils.GetChainLengthToOriginal(part)));
-        manager.Register(nameof(PartUtils.GetMergedParts), context =>
-        {
-            if (PartUtils.IsMergedPart(part))
-                return Variants.Single(PartUtils.GetMergedParts(part));
-            return Variants.Empty<ElementId>();
-        });
+        manager.Register(nameof(PartUtils.IsMergedPart), _ => PartUtils.IsMergedPart(part));
+        manager.Register(nameof(PartUtils.IsPartDerivedFromLink), _ => PartUtils.IsPartDerivedFromLink(part));
+        manager.Register(nameof(PartUtils.GetChainLengthToOriginal), _ =>PartUtils.GetChainLengthToOriginal(part));
+        manager.Register(nameof(PartUtils.GetMergedParts), _ => PartUtils.GetMergedParts(part));
         
-        manager.Register(nameof(PartUtils.ArePartsValidForDivide), context => Variants.Single(PartUtils.ArePartsValidForDivide(context, [part.Id])));
-        manager.Register(nameof(PartUtils.FindMergeableClusters), context => Variants.Single(PartUtils.FindMergeableClusters(context, [part.Id])));
-        manager.Register(nameof(PartUtils.ArePartsValidForMerge), context => Variants.Single(PartUtils.ArePartsValidForMerge(context, [part.Id])));
-        manager.Register(nameof(PartUtils.GetAssociatedPartMaker), context => Variants.Single(PartUtils.GetAssociatedPartMaker(context, part.Id)));
-        manager.Register(nameof(PartUtils.GetSplittingCurves), context => Variants.Single(PartUtils.GetSplittingCurves(context, part.Id)));
-        manager.Register(nameof(PartUtils.GetSplittingElements), context => Variants.Single(PartUtils.GetSplittingElements(context, part.Id)));
-        manager.Register(nameof(PartUtils.HasAssociatedParts), context => Variants.Single(PartUtils.HasAssociatedParts(context, part.Id)));
+        manager.Register(nameof(PartUtils.ArePartsValidForDivide), context => PartUtils.ArePartsValidForDivide(context, [part.Id]));
+        manager.Register(nameof(PartUtils.FindMergeableClusters), context => PartUtils.FindMergeableClusters(context, [part.Id]));
+        manager.Register(nameof(PartUtils.ArePartsValidForMerge), context => PartUtils.ArePartsValidForMerge(context, [part.Id]));
+        manager.Register(nameof(PartUtils.GetAssociatedPartMaker), context => PartUtils.GetAssociatedPartMaker(context, part.Id));
+        manager.Register(nameof(PartUtils.GetSplittingCurves), context => PartUtils.GetSplittingCurves(context, part.Id));
+        manager.Register(nameof(PartUtils.GetSplittingElements), context => PartUtils.GetSplittingElements(context, part.Id));
+        manager.Register(nameof(PartUtils.HasAssociatedParts), context => PartUtils.HasAssociatedParts(context, part.Id));
     }
 }

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/PartDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/PartDescriptor.cs
@@ -1,0 +1,49 @@
+// Copyright 2003-2024 by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using System.Windows.Controls;
+using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public class PartDescriptor(Part part) : ElementDescriptor(part)
+{
+    public override void RegisterExtensions(IExtensionManager manager)
+    {
+        manager.Register(nameof(PartUtils.IsMergedPart), _ => Variants.Single(PartUtils.IsMergedPart(part)));
+        manager.Register(nameof(PartUtils.IsPartDerivedFromLink), _ => Variants.Single(PartUtils.IsPartDerivedFromLink(part)));
+        manager.Register(nameof(PartUtils.GetChainLengthToOriginal), _ => Variants.Single(PartUtils.GetChainLengthToOriginal(part)));
+        manager.Register(nameof(PartUtils.GetMergedParts), context =>
+        {
+            if (PartUtils.IsMergedPart(part))
+                return Variants.Single(PartUtils.GetMergedParts(part));
+            return Variants.Empty<ElementId>();
+        });
+        
+        manager.Register(nameof(PartUtils.ArePartsValidForDivide), context => Variants.Single(PartUtils.ArePartsValidForDivide(context, [part.Id])));
+        manager.Register(nameof(PartUtils.FindMergeableClusters), context => Variants.Single(PartUtils.FindMergeableClusters(context, [part.Id])));
+        manager.Register(nameof(PartUtils.ArePartsValidForMerge), context => Variants.Single(PartUtils.ArePartsValidForMerge(context, [part.Id])));
+        manager.Register(nameof(PartUtils.GetAssociatedPartMaker), context => Variants.Single(PartUtils.GetAssociatedPartMaker(context, part.Id)));
+        manager.Register(nameof(PartUtils.GetSplittingCurves), context => Variants.Single(PartUtils.GetSplittingCurves(context, part.Id)));
+        manager.Register(nameof(PartUtils.GetSplittingElements), context => Variants.Single(PartUtils.GetSplittingElements(context, part.Id)));
+        manager.Register(nameof(PartUtils.HasAssociatedParts), context => Variants.Single(PartUtils.HasAssociatedParts(context, part.Id)));
+    }
+}

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/PartDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/PartDescriptor.cs
@@ -18,6 +18,7 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
+using System.Reflection;
 using RevitLookup.Core.Contracts;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
@@ -38,5 +39,10 @@ public class PartDescriptor(Part part) : ElementDescriptor(part)
         manager.Register(nameof(PartUtils.GetSplittingCurves), context => PartUtils.GetSplittingCurves(context, part.Id));
         manager.Register(nameof(PartUtils.GetSplittingElements), context => PartUtils.GetSplittingElements(context, part.Id));
         manager.Register(nameof(PartUtils.HasAssociatedParts), context => PartUtils.HasAssociatedParts(context, part.Id));
+    }
+    
+    public override Func<IVariants> Resolve(Document context, string target, ParameterInfo[] parameters)
+    {
+        return null;
     }
 }

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/PartMakerDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/PartMakerDescriptor.cs
@@ -19,7 +19,6 @@
 // (Rights in Technical Data and Computer Software), as applicable.
 
 using RevitLookup.Core.Contracts;
-using RevitLookup.Core.Objects;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
 
@@ -27,6 +26,6 @@ public class PartMakerDescriptor(PartMaker partMaker) : ElementDescriptor(partMa
 {
     public override void RegisterExtensions(IExtensionManager manager)
     {
-        manager.Register(nameof(PartUtils.GetPartMakerMethodToDivideVolumeFW), _ => Variants.Single(PartUtils.GetPartMakerMethodToDivideVolumeFW(partMaker)));
+        manager.Register(nameof(PartUtils.GetPartMakerMethodToDivideVolumeFW), _ => PartUtils.GetPartMakerMethodToDivideVolumeFW(partMaker));
     }
 }

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/PartMakerDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/PartMakerDescriptor.cs
@@ -18,6 +18,7 @@
 // Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
 // (Rights in Technical Data and Computer Software), as applicable.
 
+using System.Reflection;
 using RevitLookup.Core.Contracts;
 
 namespace RevitLookup.Core.ComponentModel.Descriptors;
@@ -27,5 +28,10 @@ public class PartMakerDescriptor(PartMaker partMaker) : ElementDescriptor(partMa
     public override void RegisterExtensions(IExtensionManager manager)
     {
         manager.Register(nameof(PartUtils.GetPartMakerMethodToDivideVolumeFW), _ => PartUtils.GetPartMakerMethodToDivideVolumeFW(partMaker));
+    }
+    
+    public override Func<IVariants> Resolve(Document context, string target, ParameterInfo[] parameters)
+    {
+        return null;
     }
 }

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/PartMakerDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/PartMakerDescriptor.cs
@@ -1,0 +1,32 @@
+// Copyright 2003-2024 by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using RevitLookup.Core.Contracts;
+using RevitLookup.Core.Objects;
+
+namespace RevitLookup.Core.ComponentModel.Descriptors;
+
+public class PartMakerDescriptor(PartMaker partMaker) : ElementDescriptor(partMaker)
+{
+    public override void RegisterExtensions(IExtensionManager manager)
+    {
+        manager.Register(nameof(PartUtils.GetPartMakerMethodToDivideVolumeFW), _ => Variants.Single(PartUtils.GetPartMakerMethodToDivideVolumeFW(partMaker)));
+    }
+}


### PR DESCRIPTION
# Summary of the Pull Request

I added support to some methods of PartUtils class. Most of them are extension of Part, one is of Element ans one more is of PartMaker

**Description:** 

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings