### PR TITLE
Dev edit family size table

### DIFF
--- a/source/RevitLookup/Core/ComponentModel/Descriptors/FamilySizeTableDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/FamilySizeTableDescriptor.cs
@@ -78,7 +78,7 @@ public sealed class FamilySizeTableDescriptor(FamilySizeTable table) : Descripto
                 var context = (ISnoopViewModel) contextMenu.DataContext;
                 try
                 {
-                    var dialog = new FamilySizeTableShowDialog(context.ServiceProvider, sizeTable);
+                    var dialog = new FamilySizeTableEditDialog(context.ServiceProvider, sizeTable);
                     await dialog.ShowAsync();
                 }
                 catch (Exception exception)

--- a/source/RevitLookup/Core/ComponentModel/Descriptors/FamilySizeTableManagerDescriptor.cs
+++ b/source/RevitLookup/Core/ComponentModel/Descriptors/FamilySizeTableManagerDescriptor.cs
@@ -84,13 +84,31 @@ public sealed class FamilySizeTableManagerDescriptor(FamilySizeTableManager mana
                 var context = (ISnoopViewModel) contextMenu.DataContext;
                 try
                 {
-                    var dialog = new FamilySizeTableExportDialog(context.ServiceProvider, manager);
-                    await dialog.ShowAsync();
+                    var dialog = new FamilySizeTableSelectDialog(context.ServiceProvider, manager);
+                    await dialog.ShowExportDialogAsync();
                 }
                 catch (Exception exception)
                 {
                     var logger = context.ServiceProvider.GetService<ILogger<ParameterDescriptor>>();
-                    logger.LogError(exception, "Initialize EditParameterDialog error");
+                    logger.LogError(exception, "Initialize FamilySizeTableExportDialog error");
+                }
+            });
+        
+        contextMenu.AddMenuItem("ShowMenuItem")
+            .SetHeader("Edit table")
+            .SetAvailability(manager.GetAllSizeTableNames().Count > 0)
+            .SetCommand(manager, async sizeTable =>
+            {
+                var context = (ISnoopViewModel) contextMenu.DataContext;
+                try
+                {
+                    var dialog = new FamilySizeTableSelectDialog(context.ServiceProvider, manager);
+                    await dialog.ShowEditDialogAsync();
+                }
+                catch (Exception exception)
+                {
+                    var logger = context.ServiceProvider.GetService<ILogger<FamilySizeTableDescriptor>>();
+                    logger.LogError(exception, "FamilySizeTableDialog error");
                 }
             });
     }

--- a/source/RevitLookup/ViewModels/Dialogs/FamilySizeTableSelectDialogViewModel.cs
+++ b/source/RevitLookup/ViewModels/Dialogs/FamilySizeTableSelectDialogViewModel.cs
@@ -56,7 +56,7 @@ public sealed partial class FamilySizeTableSelectDialogViewModel : ObservableObj
     {
         try
         {
-            var dialog = new FamilySizeTableShowDialog(serviceProvider, _manager, SelectedTable);
+            var dialog = new FamilySizeTableEditDialog(serviceProvider, _manager, SelectedTable);
             await dialog.ShowAsync();
         }
         catch (Exception exception)

--- a/source/RevitLookup/ViewModels/Dialogs/FamilySizeTableSelectDialogViewModel.cs
+++ b/source/RevitLookup/ViewModels/Dialogs/FamilySizeTableSelectDialogViewModel.cs
@@ -19,16 +19,19 @@
 // (Rights in Technical Data and Computer Software), as applicable.
 
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
+using RevitLookup.Core.ComponentModel.Descriptors;
+using RevitLookup.Views.Dialogs;
 
 namespace RevitLookup.ViewModels.Dialogs;
 
-public sealed partial class FamilySizeTableExportDialogViewModel : ObservableObject
+public sealed partial class FamilySizeTableSelectDialogViewModel : ObservableObject
 {
     private readonly FamilySizeTableManager _manager;
     [ObservableProperty] private string _selectedTable;
     public List<string> Tables { get; }
-    public FamilySizeTableExportDialogViewModel(FamilySizeTableManager manager)
+    public FamilySizeTableSelectDialogViewModel(FamilySizeTableManager manager)
     {
         _manager = manager;
         Tables = manager.GetAllSizeTableNames().ToList();
@@ -47,5 +50,19 @@ public sealed partial class FamilySizeTableExportDialogViewModel : ObservableObj
         if (saveFileDialog.ShowDialog() == false) return;
         
         _manager.ExportSizeTable(SelectedTable, saveFileDialog.FileName);
+    }
+    
+    public async Task ShowEditDialogAsync(IServiceProvider serviceProvider)
+    {
+        try
+        {
+            var dialog = new FamilySizeTableShowDialog(serviceProvider, _manager, SelectedTable);
+            await dialog.ShowAsync();
+        }
+        catch (Exception exception)
+        {
+            var logger = serviceProvider.GetService<ILogger<FamilySizeTableManagerDescriptor>>();
+            logger.LogError(exception, "FamilySizeTableDialog error");
+        }
     }
 }

--- a/source/RevitLookup/ViewModels/Dialogs/FamilySizeTableShowDialogViewModel.cs
+++ b/source/RevitLookup/ViewModels/Dialogs/FamilySizeTableShowDialogViewModel.cs
@@ -24,6 +24,13 @@ namespace RevitLookup.ViewModels.Dialogs;
 
 public sealed class FamilySizeTableShowDialogViewModel : DataTable
 {
+    public FamilySizeTableShowDialogViewModel(FamilySizeTableManager manager, string tableName)
+    {
+        var table = manager.GetSizeTable(tableName);
+        CreateColumns(table);
+        WriteRows(table);
+    }
+    
     public FamilySizeTableShowDialogViewModel(FamilySizeTable table)
     {
         CreateColumns(table);
@@ -48,10 +55,20 @@ public sealed class FamilySizeTableShowDialogViewModel : DataTable
     {
         for (var i = 0; i < table.NumberOfColumns; i++)
         {
+            var header = table.GetColumnHeader(i);
+            var specId = header.GetSpecTypeId();
             var typeId = table.GetColumnHeader(i).GetUnitTypeId();
             var headerName = table.GetColumnHeader(i).Name;
             
-            var columnName = typeId.Empty() ? headerName : $"{headerName}##{typeId.ToUnitLabel()}";
+            var columnName = headerName;;
+            if (!specId.Empty())
+            {
+                columnName = $"{columnName}##{specId.ToSpecLabel()}";
+            }
+            if (!typeId.Empty())
+            {
+                columnName = $"{columnName}##{typeId.ToUnitLabel()}";
+            }
             Columns.Add(new DataColumn(columnName, typeof(string)));
         }
     }

--- a/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml
+++ b/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml
@@ -1,14 +1,15 @@
 ﻿<Grid
-    x:Class="RevitLookup.Views.Dialogs.FamilySizeTableShowDialog"
+    x:Class="RevitLookup.Views.Dialogs.FamilySizeTableEditDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dialogs="clr-namespace:RevitLookup.ViewModels.Dialogs"
     mc:Ignorable="d"
-    d:DataContext="{d:DesignInstance dialogs:FamilySizeTableShowDialogViewModel}">
+    d:DataContext="{d:DesignInstance dialogs:FamilySizeTableEditDialogViewModel}">
     <DataGrid
-        IsReadOnly="True"
+        IsReadOnly="False"
+        CanUserAddRows="False"
         HeadersVisibility="Column"
         CanUserReorderColumns="False"
         ItemsSource="{Binding}" />

--- a/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml
+++ b/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml
@@ -5,6 +5,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dialogs="clr-namespace:RevitLookup.ViewModels.Dialogs"
+    xmlns:rl="http://revitlookup.com/xaml"
+    xmlns:data="clr-namespace:System.Data;assembly=System.Data"
     mc:Ignorable="d"
     d:DataContext="{d:DesignInstance dialogs:FamilySizeTableEditDialogViewModel}">
     <DataGrid
@@ -12,5 +14,38 @@
         CanUserAddRows="False"
         HeadersVisibility="Column"
         CanUserReorderColumns="False"
-        ItemsSource="{Binding}" />
+        ItemsSource="{Binding}">
+        <DataGrid.Columns>
+            <DataGridTemplateColumn IsReadOnly="True" Header="Actions">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <rl:Button 
+                                Padding="2"
+                                Margin="4 2"
+                                ToolTip="Delete row"
+                                CommandParameter="{Binding Path=DataContext.(data:DataRowView.Row), RelativeSource = {RelativeSource Self}}"
+                                Command="{Binding DataContext.DeleteRowCommand, 
+                                    RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGrid}}}">
+                                <rl:Button.Content>
+                                    <rl:SymbolIcon Symbol="Delete24" />
+                                </rl:Button.Content>
+                            </rl:Button>
+                            <rl:Button 
+                                Padding="2"
+                                Margin="4 2"
+                                ToolTip="Duplicate row"
+                                CommandParameter="{Binding Path=DataContext.(data:DataRowView.Row), RelativeSource = {RelativeSource Self}}"
+                                Command="{Binding DataContext.DuplicateRowCommand, 
+                                    RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGrid}}}">
+                                <rl:Button.Content>
+                                    <rl:SymbolIcon Symbol="Copy24" />
+                                </rl:Button.Content>
+                            </rl:Button>
+                        </StackPanel>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+        </DataGrid.Columns>
+    </DataGrid>
 </Grid>

--- a/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml.cs
+++ b/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml.cs
@@ -57,7 +57,7 @@ public sealed partial class FamilySizeTableEditDialog
             HorizontalScrollVisibility = ScrollBarVisibility.Disabled,
             VerticalScrollVisibility = ScrollBarVisibility.Disabled
         };
-        if (_isEditable)
+        if (_isEditable && Context.Document.IsFamilyDocument)
         {
             dialogOptions.PrimaryButtonText = "Save and close";
         }

--- a/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml.cs
+++ b/source/RevitLookup/Views/Dialogs/FamilySizeTableEditDialog.xaml.cs
@@ -21,25 +21,28 @@
 using System.Windows.Controls;
 using RevitLookup.ViewModels.Dialogs;
 using Wpf.Ui;
+using Wpf.Ui.Controls;
 
 namespace RevitLookup.Views.Dialogs;
 
-public sealed partial class FamilySizeTableShowDialog
+public sealed partial class FamilySizeTableEditDialog
 {
     private readonly IServiceProvider _serviceProvider;
-    private bool _isEditable;
+    private readonly bool _isEditable;
+    private readonly FamilySizeTableEditDialogViewModel _viewModel;
     
-    public FamilySizeTableShowDialog(IServiceProvider serviceProvider, FamilySizeTableManager manager, string tableName)
+    public FamilySizeTableEditDialog(IServiceProvider serviceProvider, FamilySizeTableManager manager, string tableName)
     {
         _isEditable = true;
-        DataContext = new FamilySizeTableShowDialogViewModel(manager, tableName);
+        _viewModel = new FamilySizeTableEditDialogViewModel(manager, tableName);
+        DataContext = _viewModel;
         _serviceProvider = serviceProvider;
         InitializeComponent();
     }
     
-    public FamilySizeTableShowDialog(IServiceProvider serviceProvider, FamilySizeTable table)
+    public FamilySizeTableEditDialog(IServiceProvider serviceProvider, FamilySizeTable table)
     {
-        DataContext = new FamilySizeTableShowDialogViewModel(table);
+        DataContext = new FamilySizeTableEditDialogViewModel(table);
         _serviceProvider = serviceProvider;
         InitializeComponent();
     }
@@ -59,6 +62,10 @@ public sealed partial class FamilySizeTableShowDialog
             dialogOptions.PrimaryButtonText = "Save and close";
         }
         
-        await _serviceProvider.GetService<IContentDialogService>().ShowSimpleDialogAsync(dialogOptions);
+        var dialogResult = await _serviceProvider.GetService<IContentDialogService>().ShowSimpleDialogAsync(dialogOptions);
+        if (dialogResult == ContentDialogResult.Primary)
+        {
+            _viewModel.SaveData();
+        }
     }
 }

--- a/source/RevitLookup/Views/Dialogs/FamilySizeTableSelectDialog.xaml
+++ b/source/RevitLookup/Views/Dialogs/FamilySizeTableSelectDialog.xaml
@@ -1,12 +1,12 @@
 ﻿<Grid
-    x:Class="RevitLookup.Views.Dialogs.FamilySizeTableExportDialog"
+    x:Class="RevitLookup.Views.Dialogs.FamilySizeTableSelectDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dialogs="clr-namespace:RevitLookup.ViewModels.Dialogs"
     mc:Ignorable="d"
-    d:DataContext="{d:DesignInstance dialogs:FamilySizeTableExportDialogViewModel}">
+    d:DataContext="{d:DesignInstance dialogs:FamilySizeTableSelectDialogViewModel}">
     <ComboBox
         IsReadOnly="True"
         SelectedItem="{Binding SelectedTable}"

--- a/source/RevitLookup/Views/Dialogs/FamilySizeTableSelectDialog.xaml.cs
+++ b/source/RevitLookup/Views/Dialogs/FamilySizeTableSelectDialog.xaml.cs
@@ -25,20 +25,20 @@ using Wpf.Ui.Controls;
 
 namespace RevitLookup.Views.Dialogs;
 
-public sealed partial class FamilySizeTableExportDialog
+public sealed partial class FamilySizeTableSelectDialog
 {
     private readonly IServiceProvider _serviceProvider;
-    private readonly FamilySizeTableExportDialogViewModel _viewModel;
+    private readonly FamilySizeTableSelectDialogViewModel _viewModel;
 
-    public FamilySizeTableExportDialog(IServiceProvider serviceProvider, FamilySizeTableManager manager)
+    public FamilySizeTableSelectDialog(IServiceProvider serviceProvider, FamilySizeTableManager manager)
     {
-        _viewModel = new FamilySizeTableExportDialogViewModel(manager);
+        _viewModel = new FamilySizeTableSelectDialogViewModel(manager);
         DataContext = _viewModel;
         _serviceProvider = serviceProvider;
         InitializeComponent();
     }
     
-    public async Task ShowAsync()
+    public async Task ShowExportDialogAsync()
     {
         var dialogOptions = new SimpleContentDialogCreateOptions
         {
@@ -56,6 +56,32 @@ public sealed partial class FamilySizeTableExportDialog
         try
         {
             _viewModel.Export();
+        }
+        catch (Exception exception)
+        {
+            var notificationService = _serviceProvider.GetService<NotificationService>();
+            notificationService.ShowWarning("Export error", exception.Message);
+        }
+    }
+    
+    public async Task ShowEditDialogAsync()
+    {
+        var dialogOptions = new SimpleContentDialogCreateOptions
+        {
+            Title = "Select family size table",
+            Content = this,
+            PrimaryButtonText = "Edit",
+            CloseButtonText = "Close",
+            DialogMaxHeight = 230,
+            DialogMaxWidth = 500
+        };
+        
+        var dialogResult = await _serviceProvider.GetService<IContentDialogService>().ShowSimpleDialogAsync(dialogOptions);
+        if (dialogResult != ContentDialogResult.Primary) return;
+        
+        try
+        {
+             await _viewModel.ShowEditDialogAsync(_serviceProvider);
         }
         catch (Exception exception)
         {

--- a/source/RevitLookup/Views/Dialogs/FamilySizeTableShowDialog.xaml.cs
+++ b/source/RevitLookup/Views/Dialogs/FamilySizeTableShowDialog.xaml.cs
@@ -27,6 +27,15 @@ namespace RevitLookup.Views.Dialogs;
 public sealed partial class FamilySizeTableShowDialog
 {
     private readonly IServiceProvider _serviceProvider;
+    private bool _isEditable;
+    
+    public FamilySizeTableShowDialog(IServiceProvider serviceProvider, FamilySizeTableManager manager, string tableName)
+    {
+        _isEditable = true;
+        DataContext = new FamilySizeTableShowDialogViewModel(manager, tableName);
+        _serviceProvider = serviceProvider;
+        InitializeComponent();
+    }
     
     public FamilySizeTableShowDialog(IServiceProvider serviceProvider, FamilySizeTable table)
     {
@@ -45,6 +54,10 @@ public sealed partial class FamilySizeTableShowDialog
             HorizontalScrollVisibility = ScrollBarVisibility.Disabled,
             VerticalScrollVisibility = ScrollBarVisibility.Disabled
         };
+        if (_isEditable)
+        {
+            dialogOptions.PrimaryButtonText = "Save and close";
+        }
         
         await _serviceProvider.GetService<IContentDialogService>().ShowSimpleDialogAsync(dialogOptions);
     }


### PR DESCRIPTION
# Summary of the Pull Request

I add possibility to edit Family Size Tables in Lookup

**Description:** 

Now user can see tables from tableDescriptor and TableManagerDescriptor. If user sees from Manager, they should choose a table from ComboBox, so I rename the class for export dialog, now it's select dialog

Also user can duplicate rows, delete rows and change values
User are not allowed to change table in family document

## Quality Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings