### PR TITLE
Supress GenericHost startup messages

### DIFF
--- a/source/RevitLookup/Host.cs
+++ b/source/RevitLookup/Host.cs
@@ -42,6 +42,7 @@ public static class Host
         
         //Configuration
         builder.Services.AddOptions(builder.Configuration);
+        builder.Services.Configure<ConsoleLifetimeOptions>(opt => opt.SuppressStatusMessages = true);
         
         //Application services
         builder.Services.AddSingleton<ISettingsService, SettingsService>();


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 
GenericHost automatically logs certain messages to console output when starting/stopping.
This change would suppress these messages.
(Also, Ctrl+C does nothing because we are running in revit and not in a console window)
```
[INF] Microsoft.Hosting.Lifetime: Application started. Press Ctrl+C to shut down.
[INF] Microsoft.Hosting.Lifetime: Hosting environment: Production
[INF] Microsoft.Hosting.Lifetime: Content root path: <AddInDirectory>
```

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings