### PR TITLE
Add LogLevel Setting

### DIFF
--- a/source/RevitLookup/Config/GeneralConfiguration.cs
+++ b/source/RevitLookup/Config/GeneralConfiguration.cs
@@ -57,5 +57,5 @@ public sealed class GeneralConfiguration
     [JsonPropertyName("ShowMemoryColumn")] public bool ShowMemoryColumn { get; set; }
     [JsonPropertyName("UseSizeRestoring")] public bool UseSizeRestoring { get; set; }
     [JsonPropertyName("IsModifyTabAllowed")] public bool UseModifyTab { get; set; }
-    [JsonPropertyName("LogEventLevel")] public LogEventLevel LogEventLevel { get; set; } = LogEventLevel.Information;
+    [JsonPropertyName("LogLevel")] public LogLevel LogLevel { get; set; } = LogLevel.Information;
 }

--- a/source/RevitLookup/Config/GeneralConfiguration.cs
+++ b/source/RevitLookup/Config/GeneralConfiguration.cs
@@ -19,7 +19,6 @@
 // (Rights in Technical Data and Computer Software), as applicable.
 
 using System.Text.Json.Serialization;
-using Serilog.Events;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 

--- a/source/RevitLookup/Config/GeneralConfiguration.cs
+++ b/source/RevitLookup/Config/GeneralConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2024 by Autodesk, Inc.
+// Copyright 2003-2024 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -19,6 +19,7 @@
 // (Rights in Technical Data and Computer Software), as applicable.
 
 using System.Text.Json.Serialization;
+using Serilog.Events;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 
@@ -56,4 +57,5 @@ public sealed class GeneralConfiguration
     [JsonPropertyName("ShowMemoryColumn")] public bool ShowMemoryColumn { get; set; }
     [JsonPropertyName("UseSizeRestoring")] public bool UseSizeRestoring { get; set; }
     [JsonPropertyName("IsModifyTabAllowed")] public bool UseModifyTab { get; set; }
+    [JsonPropertyName("LogEventLevel")] public LogEventLevel LogEventLevel { get; set; } = LogEventLevel.Information;
 }

--- a/source/RevitLookup/Config/LoggerConfigurator.cs
+++ b/source/RevitLookup/Config/LoggerConfigurator.cs
@@ -36,3 +36,13 @@ public static class LoggerConfigurator
         logger.LogCritical(exception, "Domain unhandled exception");
     }
 }
+
+public enum LogLevel
+{
+    Verbose = 0,
+    Debug = 1,
+    Information = 2,
+    Warning = 3,
+    Error = 4,
+    Fatal = 5
+}

--- a/source/RevitLookup/Config/LoggerConfigurator.cs
+++ b/source/RevitLookup/Config/LoggerConfigurator.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using RevitLookup.Services;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -9,14 +10,15 @@ public static class LoggerConfigurator
 {
     private const string LogTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss} [{Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}";
 
-    public static LoggingLevelSwitch AddSerilogConfiguration(this ILoggingBuilder builder, LoggingLevelSwitch loggingLevelSwitch = null)
+    public static LoggingLevelService AddSerilogConfiguration(this ILoggingBuilder builder)
     {
-        loggingLevelSwitch ??= new LoggingLevelSwitch();
+        var loggingLevelSwitch = new LoggingLevelSwitch();
+        var loggingLevelService = new LoggingLevelService(loggingLevelSwitch);
         var logger = CreateDefaultLogger(loggingLevelSwitch);
         builder.AddSerilog(logger);
 
         AppDomain.CurrentDomain.UnhandledException += OnOnUnhandledException;
-        return loggingLevelSwitch;
+        return loggingLevelService;
     }
 
     private static Logger CreateDefaultLogger(LoggingLevelSwitch loggingLevelSwitch)

--- a/source/RevitLookup/Host.cs
+++ b/source/RevitLookup/Host.cs
@@ -38,14 +38,13 @@ public static class Host
 
         //Logging
         builder.Logging.ClearProviders();
-        var loggingLevelSwitch = builder.Logging.AddSerilogConfiguration();
+        var loggingLevelService = builder.Logging.AddSerilogConfiguration();
 
         //Configuration
         builder.Services.AddOptions(builder.Configuration);
 
         //Application services
-        builder.Services.AddSingleton(loggingLevelSwitch);
-        builder.Services.AddSingleton<LoggingLevelService>();
+        builder.Services.AddSingleton<ILoggingLevelService>(loggingLevelService);
         builder.Services.AddSingleton<ISettingsService, SettingsService>();
         builder.Services.AddSingleton<ISoftwareUpdateService, SoftwareUpdateService>();
         builder.Services.AddHostedService<HostedLifecycleService>();

--- a/source/RevitLookup/Host.cs
+++ b/source/RevitLookup/Host.cs
@@ -38,12 +38,13 @@ public static class Host
 
         //Logging
         builder.Logging.ClearProviders();
-        builder.Logging.AddSerilogConfiguration();
+        var loggingLevelSwitch = builder.Logging.AddSerilogConfiguration();
 
         //Configuration
         builder.Services.AddOptions(builder.Configuration);
 
         //Application services
+        builder.Services.AddSingleton(loggingLevelSwitch);
         builder.Services.AddSingleton<ISettingsService, SettingsService>();
         builder.Services.AddSingleton<ISoftwareUpdateService, SoftwareUpdateService>();
         builder.Services.AddHostedService<HostedLifecycleService>();

--- a/source/RevitLookup/Host.cs
+++ b/source/RevitLookup/Host.cs
@@ -45,6 +45,7 @@ public static class Host
 
         //Application services
         builder.Services.AddSingleton(loggingLevelSwitch);
+        builder.Services.AddSingleton<LoggingLevelService>();
         builder.Services.AddSingleton<ISettingsService, SettingsService>();
         builder.Services.AddSingleton<ISoftwareUpdateService, SoftwareUpdateService>();
         builder.Services.AddHostedService<HostedLifecycleService>();

--- a/source/RevitLookup/Models/Settings/GeneralSettings.cs
+++ b/source/RevitLookup/Models/Settings/GeneralSettings.cs
@@ -23,7 +23,6 @@ using System.Text.Json;
 using Microsoft.Extensions.Options;
 using RevitLookup.Config;
 using RevitLookup.Services.Contracts;
-using Serilog.Events;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 
@@ -135,10 +134,10 @@ public sealed class GeneralSettings(string path, IOptions<JsonSerializerOptions>
         set => _settings.IncludeRootHierarchy = value;
     }
 
-    public LogEventLevel LogEventLevel
+    public LogLevel LogLevel
     {
-        get => _settings.LogEventLevel;
-        set => _settings.LogEventLevel = value;
+        get => _settings.LogLevel;
+        set => _settings.LogLevel = value;
     }
 
     public int ApplyTransition(bool value)

--- a/source/RevitLookup/Models/Settings/GeneralSettings.cs
+++ b/source/RevitLookup/Models/Settings/GeneralSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2024 by Autodesk, Inc.
+// Copyright 2003-2024 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -23,6 +23,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Options;
 using RevitLookup.Config;
 using RevitLookup.Services.Contracts;
+using Serilog.Events;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 
@@ -133,7 +134,13 @@ public sealed class GeneralSettings(string path, IOptions<JsonSerializerOptions>
         get => _settings.IncludeRootHierarchy;
         set => _settings.IncludeRootHierarchy = value;
     }
-    
+
+    public LogEventLevel LogEventLevel
+    {
+        get => _settings.LogEventLevel;
+        set => _settings.LogEventLevel = value;
+    }
+
     public int ApplyTransition(bool value)
     {
         return TransitionDuration = value ? _settings.DefaultTransitionDuration : 0;

--- a/source/RevitLookup/RevitLookup.csproj
+++ b/source/RevitLookup/RevitLookup.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <UseWPF>true</UseWPF>

--- a/source/RevitLookup/Services/Contracts/ILoggingLevelService.cs
+++ b/source/RevitLookup/Services/Contracts/ILoggingLevelService.cs
@@ -19,27 +19,11 @@
 // (Rights in Technical Data and Computer Software), as applicable.
 
 using RevitLookup.Config;
-using RevitLookup.Services.Contracts;
-using Serilog.Core;
-using Serilog.Events;
 
-namespace RevitLookup.Services;
+namespace RevitLookup.Services.Contracts;
 
-public sealed class LoggingLevelService : ILoggingLevelService
+public interface ILoggingLevelService
 {
-    private readonly LoggingLevelSwitch _loggingLevelSwitch;
-    public LoggingLevelService(LoggingLevelSwitch loggingLevelSwitch)
-    {
-        _loggingLevelSwitch = loggingLevelSwitch;
-    }
-
-    public void SetLogLevel(LogLevel logLevel)
-    {
-        _loggingLevelSwitch.MinimumLevel = (LogEventLevel) logLevel;
-    }
-
-    public LogLevel GetLogLevel()
-    {
-        return (LogLevel) _loggingLevelSwitch.MinimumLevel;
-    }
+    void SetLogLevel(LogLevel logLevel);
+    LogLevel GetLogLevel();
 }

--- a/source/RevitLookup/Services/HostedLifecycleService.cs
+++ b/source/RevitLookup/Services/HostedLifecycleService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2024 by Autodesk, Inc.
+// Copyright 2003-2024 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,

--- a/source/RevitLookup/Services/LoggingLevelService.cs
+++ b/source/RevitLookup/Services/LoggingLevelService.cs
@@ -1,0 +1,44 @@
+// Copyright 2003-2024 by Autodesk, Inc.
+// 
+// Permission to use, copy, modify, and distribute this software in
+// object code form for any purpose and without fee is hereby granted,
+// provided that the above copyright notice appears in all copies and
+// that both that copyright notice and the limited warranty and
+// restricted rights notice below appear in all supporting
+// documentation.
+// 
+// AUTODESK PROVIDES THIS PROGRAM "AS IS" AND WITH ALL FAULTS.
+// AUTODESK SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTY OF
+// MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE.  AUTODESK, INC.
+// DOES NOT WARRANT THAT THE OPERATION OF THE PROGRAM WILL BE
+// UNINTERRUPTED OR ERROR FREE.
+// 
+// Use, duplication, or disclosure by the U.S. Government is subject to
+// restrictions set forth in FAR 52.227-19 (Commercial Computer
+// Software - Restricted Rights) and DFAR 252.227-7013(c)(1)(ii)
+// (Rights in Technical Data and Computer Software), as applicable.
+
+using RevitLookup.Config;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace RevitLookup.Services;
+
+public sealed class LoggingLevelService
+{
+    private readonly LoggingLevelSwitch _loggingLevelSwitch;
+    public LoggingLevelService(LoggingLevelSwitch loggingLevelSwitch)
+    {
+        _loggingLevelSwitch = loggingLevelSwitch;
+    }
+
+    public void SetLogLevel(LogLevel logLevel)
+    {
+        _loggingLevelSwitch.MinimumLevel = (LogEventLevel) logLevel;
+    }
+
+    public LogLevel GetLogLevel()
+    {
+        return (LogLevel) _loggingLevelSwitch.MinimumLevel;
+    }
+}

--- a/source/RevitLookup/Services/LoggingLevelService.cs
+++ b/source/RevitLookup/Services/LoggingLevelService.cs
@@ -25,21 +25,15 @@ using Serilog.Events;
 
 namespace RevitLookup.Services;
 
-public sealed class LoggingLevelService : ILoggingLevelService
+public sealed class LoggingLevelService(LoggingLevelSwitch loggingLevelSwitch) : ILoggingLevelService
 {
-    private readonly LoggingLevelSwitch _loggingLevelSwitch;
-    public LoggingLevelService(LoggingLevelSwitch loggingLevelSwitch)
-    {
-        _loggingLevelSwitch = loggingLevelSwitch;
-    }
-
     public void SetLogLevel(LogLevel logLevel)
     {
-        _loggingLevelSwitch.MinimumLevel = (LogEventLevel) logLevel;
+        loggingLevelSwitch.MinimumLevel = (LogEventLevel) logLevel;
     }
 
     public LogLevel GetLogLevel()
     {
-        return (LogLevel) _loggingLevelSwitch.MinimumLevel;
+        return (LogLevel) loggingLevelSwitch.MinimumLevel;
     }
 }

--- a/source/RevitLookup/Services/SettingsService.cs
+++ b/source/RevitLookup/Services/SettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2024 by Autodesk, Inc.
+// Copyright 2003-2024 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -24,16 +24,19 @@ using Microsoft.Extensions.Options;
 using RevitLookup.Models.Options;
 using RevitLookup.Models.Settings;
 using RevitLookup.Services.Contracts;
+using Serilog.Core;
 
 namespace RevitLookup.Services;
 
 public sealed class SettingsService : ISettingsService
 {
     private readonly ILogger<SettingsService> _logger;
-    
-    public SettingsService(IOptions<FolderLocations> foldersOptions, IOptions<JsonSerializerOptions> jsonOptions, ILogger<SettingsService> logger)
+    private readonly LoggingLevelSwitch _loggingLevelSwitch;
+
+    public SettingsService(LoggingLevelSwitch loggingLevelSwitch, IOptions<FolderLocations> foldersOptions, IOptions<JsonSerializerOptions> jsonOptions, ILogger<SettingsService> logger)
     {
         _logger = logger;
+        _loggingLevelSwitch = loggingLevelSwitch;
         GeneralSettings = new GeneralSettings(foldersOptions.Value.GeneralSettingsPath, jsonOptions);
         RenderSettings = new RenderSettings(foldersOptions.Value.RenderSettingsPath, jsonOptions);
         
@@ -69,6 +72,7 @@ public sealed class SettingsService : ISettingsService
         try
         {
             GeneralSettings.Load();
+            _loggingLevelSwitch.MinimumLevel = GeneralSettings.LogEventLevel;
         }
         catch (Exception exception)
         {

--- a/source/RevitLookup/Services/SettingsService.cs
+++ b/source/RevitLookup/Services/SettingsService.cs
@@ -24,19 +24,18 @@ using Microsoft.Extensions.Options;
 using RevitLookup.Models.Options;
 using RevitLookup.Models.Settings;
 using RevitLookup.Services.Contracts;
-using Serilog.Core;
 
 namespace RevitLookup.Services;
 
 public sealed class SettingsService : ISettingsService
 {
     private readonly ILogger<SettingsService> _logger;
-    private readonly LoggingLevelSwitch _loggingLevelSwitch;
+    private readonly LoggingLevelService _loggingLevelService;
 
-    public SettingsService(LoggingLevelSwitch loggingLevelSwitch, IOptions<FolderLocations> foldersOptions, IOptions<JsonSerializerOptions> jsonOptions, ILogger<SettingsService> logger)
+    public SettingsService(LoggingLevelService loggingLevelService, IOptions<FolderLocations> foldersOptions, IOptions<JsonSerializerOptions> jsonOptions, ILogger<SettingsService> logger)
     {
         _logger = logger;
-        _loggingLevelSwitch = loggingLevelSwitch;
+        _loggingLevelService = loggingLevelService;
         GeneralSettings = new GeneralSettings(foldersOptions.Value.GeneralSettingsPath, jsonOptions);
         RenderSettings = new RenderSettings(foldersOptions.Value.RenderSettingsPath, jsonOptions);
         
@@ -72,7 +71,7 @@ public sealed class SettingsService : ISettingsService
         try
         {
             GeneralSettings.Load();
-            _loggingLevelSwitch.MinimumLevel = GeneralSettings.LogEventLevel;
+            _loggingLevelService.SetLogLevel(GeneralSettings.LogLevel);
         }
         catch (Exception exception)
         {

--- a/source/RevitLookup/Services/SettingsService.cs
+++ b/source/RevitLookup/Services/SettingsService.cs
@@ -30,9 +30,9 @@ namespace RevitLookup.Services;
 public sealed class SettingsService : ISettingsService
 {
     private readonly ILogger<SettingsService> _logger;
-    private readonly LoggingLevelService _loggingLevelService;
+    private readonly ILoggingLevelService _loggingLevelService;
 
-    public SettingsService(LoggingLevelService loggingLevelService, IOptions<FolderLocations> foldersOptions, IOptions<JsonSerializerOptions> jsonOptions, ILogger<SettingsService> logger)
+    public SettingsService(ILoggingLevelService loggingLevelService, IOptions<FolderLocations> foldersOptions, IOptions<JsonSerializerOptions> jsonOptions, ILogger<SettingsService> logger)
     {
         _logger = logger;
         _loggingLevelService = loggingLevelService;

--- a/source/RevitLookup/ViewModels/Converters/LogLevelConverter.cs
+++ b/source/RevitLookup/ViewModels/Converters/LogLevelConverter.cs
@@ -1,4 +1,4 @@
-// Copyright 2003-2024 by Autodesk, Inc.
+﻿// Copyright 2003-2024 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -21,52 +21,24 @@
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Markup;
-using Wpf.Ui.Appearance;
-using Wpf.Ui.Controls;
+using RevitLookup.Config;
 
 namespace RevitLookup.ViewModels.Converters;
 
-[ValueConversion(typeof(WindowBackdropType), typeof(string))]
-public sealed class BackgroundTypeConverter : MarkupExtension, IValueConverter
+[ValueConversion(typeof(LogLevel), typeof(string))]
+public sealed class LogLevelConverter : MarkupExtension, IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        var backgroundType = (WindowBackdropType) value!;
-        return backgroundType switch
-        {
-            WindowBackdropType.None => "Disabled",
-            WindowBackdropType.Acrylic => "Acrylic",
-            WindowBackdropType.Tabbed => "Blur",
-            WindowBackdropType.Mica => "Mica",
-            WindowBackdropType.Auto => "Windows default",
-            _ => throw new ArgumentOutOfRangeException()
-        };
-    }
-
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        throw new NotSupportedException();
-    }
-
-    public override object ProvideValue(IServiceProvider serviceProvider)
-    {
-        return this;
-    }
-}
-
-[ValueConversion(typeof(ApplicationTheme), typeof(string))]
-public sealed class ApplicationThemeConverter : MarkupExtension, IValueConverter
-{
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        var applicationTheme = (ApplicationTheme) value!;
+        var applicationTheme = (LogLevel) value!;
         return applicationTheme switch
         {
-            ApplicationTheme.Auto => "Auto",
-            ApplicationTheme.Light => "Light",
-            ApplicationTheme.Dark => "Dark",
-            ApplicationTheme.HighContrast => "High contrast",
-            ApplicationTheme.Unknown => throw new NotSupportedException(),
+            LogLevel.Verbose => "Verbose",
+            LogLevel.Debug => "Debug",
+            LogLevel.Information => "Information",
+            LogLevel.Warning => "Warning",
+            LogLevel.Error => "Error",
+            LogLevel.Fatal => "Fatal",
             _ => throw new ArgumentOutOfRangeException()
         };
     }

--- a/source/RevitLookup/ViewModels/Converters/ThemeConverters.cs
+++ b/source/RevitLookup/ViewModels/Converters/ThemeConverters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2003-2024 by Autodesk, Inc.
+// Copyright 2003-2024 by Autodesk, Inc.
 // 
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,
@@ -21,6 +21,7 @@
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Markup;
+using Serilog.Events;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 
@@ -67,6 +68,35 @@ public sealed class ApplicationThemeConverter : MarkupExtension, IValueConverter
             ApplicationTheme.Dark => "Dark",
             ApplicationTheme.HighContrast => "High contrast",
             ApplicationTheme.Unknown => throw new NotSupportedException(),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        return this;
+    }
+}
+
+[ValueConversion(typeof(LogEventLevel), typeof(string))]
+public sealed class LogEventLevelConverter : MarkupExtension, IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var applicationTheme = (LogEventLevel) value!;
+        return applicationTheme switch
+        {
+            LogEventLevel.Verbose => "Verbose",
+            LogEventLevel.Debug => "Debug",
+            LogEventLevel.Information => "Information",
+            LogEventLevel.Warning => "Warning",
+            LogEventLevel.Error => "Error",
+            LogEventLevel.Fatal => "Fatal",
             _ => throw new ArgumentOutOfRangeException()
         };
     }

--- a/source/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
@@ -25,6 +25,9 @@ using RevitLookup.Views.Dialogs;
 using Wpf.Ui;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
+using Serilog.Events;
+using Serilog.Core;
+
 #if REVIT2024_OR_GREATER
 using RevitLookup.Views.Appearance;
 #endif
@@ -36,6 +39,7 @@ public sealed partial class SettingsViewModel(
     INavigationService navigationService,
     IServiceProvider serviceProvider,
     NotificationService notificationService,
+    LoggingLevelSwitch loggingLevelSwitch,
     IWindow window)
     : ObservableObject
 {
@@ -47,6 +51,7 @@ public sealed partial class SettingsViewModel(
     [ObservableProperty] private bool _useSizeRestoring = settingsService.GeneralSettings.UseSizeRestoring;
     [ObservableProperty] private bool _useModifyTab = settingsService.GeneralSettings.UseModifyTab;
 
+    [ObservableProperty] private LogEventLevel _logEventLevel = settingsService.GeneralSettings.LogEventLevel;
     public List<ApplicationTheme> Themes { get; } =
     [
 #if REVIT2024_OR_GREATER
@@ -63,6 +68,16 @@ public sealed partial class SettingsViewModel(
         WindowBackdropType.Acrylic,
         WindowBackdropType.Tabbed,
         WindowBackdropType.Mica
+    ];
+
+    public List<LogEventLevel> LogEventLevels { get; } =
+    [
+        LogEventLevel.Verbose,
+        LogEventLevel.Debug,
+        LogEventLevel.Information,
+        LogEventLevel.Warning,
+        LogEventLevel.Error,
+        LogEventLevel.Fatal
     ];
 
     [RelayCommand]
@@ -164,5 +179,11 @@ public sealed partial class SettingsViewModel(
     {
         settingsService.GeneralSettings.UseModifyTab = value;
         RibbonController.ReloadPanels();
+    }
+
+    partial void OnLogEventLevelChanged(LogEventLevel value)
+    {
+        settingsService.GeneralSettings.LogEventLevel = value;
+        loggingLevelSwitch.MinimumLevel = value;
     }
 }

--- a/source/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
@@ -25,9 +25,7 @@ using RevitLookup.Views.Dialogs;
 using Wpf.Ui;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
-using Serilog.Events;
-using Serilog.Core;
-
+using RevitLookup.Config;
 #if REVIT2024_OR_GREATER
 using RevitLookup.Views.Appearance;
 #endif
@@ -39,7 +37,7 @@ public sealed partial class SettingsViewModel(
     INavigationService navigationService,
     IServiceProvider serviceProvider,
     NotificationService notificationService,
-    LoggingLevelSwitch loggingLevelSwitch,
+    LoggingLevelService loggingLevelService,
     IWindow window)
     : ObservableObject
 {
@@ -51,7 +49,7 @@ public sealed partial class SettingsViewModel(
     [ObservableProperty] private bool _useSizeRestoring = settingsService.GeneralSettings.UseSizeRestoring;
     [ObservableProperty] private bool _useModifyTab = settingsService.GeneralSettings.UseModifyTab;
 
-    [ObservableProperty] private LogEventLevel _logEventLevel = settingsService.GeneralSettings.LogEventLevel;
+    [ObservableProperty] private LogLevel _logLevel = settingsService.GeneralSettings.LogLevel;
     public List<ApplicationTheme> Themes { get; } =
     [
 #if REVIT2024_OR_GREATER
@@ -70,14 +68,14 @@ public sealed partial class SettingsViewModel(
         WindowBackdropType.Mica
     ];
 
-    public List<LogEventLevel> LogEventLevels { get; } =
+    public List<LogLevel> LogLevels { get; } =
     [
-        LogEventLevel.Verbose,
-        LogEventLevel.Debug,
-        LogEventLevel.Information,
-        LogEventLevel.Warning,
-        LogEventLevel.Error,
-        LogEventLevel.Fatal
+        LogLevel.Verbose,
+        LogLevel.Debug,
+        LogLevel.Information,
+        LogLevel.Warning,
+        LogLevel.Error,
+        LogLevel.Fatal
     ];
 
     [RelayCommand]
@@ -181,9 +179,9 @@ public sealed partial class SettingsViewModel(
         RibbonController.ReloadPanels();
     }
 
-    partial void OnLogEventLevelChanged(LogEventLevel value)
+    partial void OnLogLevelChanged(LogLevel value)
     {
-        settingsService.GeneralSettings.LogEventLevel = value;
-        loggingLevelSwitch.MinimumLevel = value;
+        settingsService.GeneralSettings.LogLevel = value;
+        loggingLevelService.SetLogLevel(value);
     }
 }

--- a/source/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
+++ b/source/RevitLookup/ViewModels/Pages/SettingsViewModel.cs
@@ -37,7 +37,7 @@ public sealed partial class SettingsViewModel(
     INavigationService navigationService,
     IServiceProvider serviceProvider,
     NotificationService notificationService,
-    LoggingLevelService loggingLevelService,
+    ILoggingLevelService loggingLevelService,
     IWindow window)
     : ObservableObject
 {

--- a/source/RevitLookup/Views/Pages/SettingsPage.xaml
+++ b/source/RevitLookup/Views/Pages/SettingsPage.xaml
@@ -100,18 +100,18 @@
             <StackPanel
                 Margin="0,8,0,0">
                 <rl:CardControl
-                    Header="Minimal Log Event Level"
+                    Header="Minimal Log Level"
                     Icon="{rl:SymbolIcon Info24}"
                     Margin="0,8,0,0">
                     <ComboBox
                         MinWidth="150"
                         IsEnabled="True"
-                        SelectedItem="{Binding ViewModel.LogEventLevel}"
-                        ItemsSource="{Binding ViewModel.LogEventLevels}">
+                        SelectedItem="{Binding ViewModel.LogLevel}"
+                        ItemsSource="{Binding ViewModel.LogLevels}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
                                 <TextBlock
-                                Text="{Binding ., Converter={converters:LogEventLevelConverter}}" />
+                                Text="{Binding ., Converter={converters:LogLevelConverter}}" />
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>

--- a/source/RevitLookup/Views/Pages/SettingsPage.xaml
+++ b/source/RevitLookup/Views/Pages/SettingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="RevitLookup.Views.Pages.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -99,6 +99,23 @@
                 Margin="0,17,0,0" />
             <StackPanel
                 Margin="0,8,0,0">
+                <rl:CardControl
+                    Header="Minimal Log Event Level"
+                    Icon="{rl:SymbolIcon Info24}"
+                    Margin="0,8,0,0">
+                    <ComboBox
+                        MinWidth="150"
+                        IsEnabled="True"
+                        SelectedItem="{Binding ViewModel.LogEventLevel}"
+                        ItemsSource="{Binding ViewModel.LogEventLevels}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock
+                                Text="{Binding ., Converter={converters:LogEventLevelConverter}}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </rl:CardControl>
                 <rl:CardAction
                     Content="Reset setting"
                     Icon="{rl:SymbolIcon ArrowReset24}"


### PR DESCRIPTION
# Summary of the Pull Request

Add setting to control the log level of the RevitLookup.

**What is this about:** 

The current version of RevitLookup use the fix level Debug, this PR allow to change the level to prevent unwanted log in the Console.

The default setting for the Minimal Log Level is `Information`, and could be changed in the `Setting -> Other`.

![image](https://github.com/user-attachments/assets/a001f749-4e1e-4015-823a-4cf5d5c8bff3)

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings