### PR TITLE
Typo mistake bundle folder should be `Contents`

### DIFF
--- a/build/Modules/CreateBundleModule.cs
+++ b/build/Modules/CreateBundleModule.cs
@@ -37,7 +37,7 @@ public sealed partial class CreateBundleModule(IOptions<BuildOptions> buildOptio
 
         var outputFolder = context.Git().RootDirectory.GetFolder(buildOptions.Value.OutputDirectory);
         var bundleFolder = outputFolder.CreateFolder($"{bundleTarget.NameWithoutExtension}.bundle");
-        var contentFolder = bundleFolder.CreateFolder("Content");
+        var contentFolder = bundleFolder.CreateFolder("Contents");
         var manifestFile = bundleFolder.GetFile("PackageContents.xml");
 
         PackFiles(targetDirectories, contentFolder);


### PR DESCRIPTION
# Summary of the Pull Request

The `s` is missing in the folder `Contents` to match `PackageContents.xml` component. 

The bundle `https://github.com/lookup-foundation/RevitLookup/releases/download/2027.0.0-preview.1/RevitLookup.bundle.zip` does not work, Revit ignore the bundle and does not show any error message.

**What is this about:** 

Related to #358 