### PR TITLE
fix entity descriptor bug on double fields

### DIFF
--- a/source/RevitLookup/Core/Decomposition/Descriptors/EntityDescriptor.cs
+++ b/source/RevitLookup/Core/Decomposition/Descriptors/EntityDescriptor.cs
@@ -39,6 +39,9 @@ public sealed class EntityDescriptor(Entity entity) : Descriptor, IDescriptorRes
             var variants = Variants.Values<object>(fields.Count);
             foreach (var field in fields)
             {
+                //for double we always need UnitTypeId, so we can not see these fields when we use the overload with fieldName only
+                if (field.ValueType == typeof(double) || field.KeyType == typeof(double)) continue;
+
                 var method = entity.GetType().GetMethod(nameof(Entity.Get), [typeof(Field)])!;
                 var genericMethod = MakeGenericInvoker(field, method);
                 variants.Add(genericMethod.Invoke(entity, [field]), field.FieldName);


### PR DESCRIPTION
# Summary of the Pull Request

**What is this about:** 

**Description:** 

When an entity has fields with double value or key types, we had an exception when try to resolve method Get(string fieldName) because it always needs unitTypeId.  I skip such fields in thos resolve

## Quality Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings