### PR TITLE
Update GitHub API URL in HttpClientConfiguration

### DIFF
--- a/source/RevitLookup/Configuration/HttpClientConfiguration.cs
+++ b/source/RevitLookup/Configuration/HttpClientConfiguration.cs
@@ -9,7 +9,7 @@ public static class HttpClientConfiguration
 {
     public static TBuilder ConfigureHttpClients<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
-        builder.Services.AddHttpClient("GitHubSource", client => client.BaseAddress = new Uri("https://api.github.com/repos/jeremytammik/RevitLookup/"));
+        builder.Services.AddHttpClient("GitHubSource", client => client.BaseAddress = new Uri("https://api.github.com/repos/lookup-foundation/RevitLookup/"));
         
         builder.Services.ConfigureHttpClientDefaults(clientBuilder => clientBuilder.RemoveAllLoggers());
         builder.Services.RemoveAll<IHttpMessageHandlerBuilderFilter>();


### PR DESCRIPTION


**Description:** 

The project has migrated to lookup-foundation/RevitLookup, but the HTTP client still points at the original personal repo jeremytammik/RevitLookup. 

GitHub currently forwards this, but if the repo is ever deleted or the fork becomes divergent, the update check silently fails or, worse, returns stale release data. If someone were to reclaim jeremytammik/RevitLookup as a fresh repo under a different owner they could serve arbitrary "latest release" payloads